### PR TITLE
fix(ci): restrict npm publishing to release events only

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -48,7 +48,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Publish to npm
-        if: github.event_name == 'push'
+        if: github.event_name == 'release' && github.event.action == 'published'
         uses: JS-DevTools/npm-publish@v2
         with:
           strategy: upgrade


### PR DESCRIPTION
BREAKING CHANGE: npm packages will now only be published when a GitHub release is published, rather than on every push to the main branch. This ensures more controlled and intentional releases.

<!-- ps-id: 615b66a8-8087-4d42-855f-35a76c2a7026 -->