### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,5 +1,7 @@
 name: CI/CD Pipeline
 on: [push, pull_request]
+permissions:
+  contents: read
 
 jobs:
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/cawalch/wingnut/security/code-scanning/5](https://github.com/cawalch/wingnut/security/code-scanning/5)

To correct this issue, add a `permissions` block at the highest level of the workflow (before `jobs:`), unless fine-grained control per-job is desired. The permission set should be as restrictive as possible while allowing the workflow to function. For typical CI/CD workflows, reading repository contents is necessary (`contents: read`), and if the workflow requires additional permissions (like publishing a release or commenting on PRs), those write permissions should be added specifically.

In this workflow, most of the steps involve installing dependencies, building, linting, testing, and reporting coverage, all of which only need read access to contents. The publish to npm step relies on an NPM token, not `GITHUB_TOKEN`, so it doesn't need extra GitHub permissions unless it interacts with the repository via API (which it doesn't here). Thus, a minimal permissions block is:

```yaml
permissions:
  contents: read
```

Insert this block after the workflow’s name and triggering events, before `jobs:`. No extra imports, method definitions, or further changes are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
