### PR TITLE
fix: scopeWrapper no longer passes next to scope handlers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.pi
 coverage
 dist
 node_modules

--- a/BUGS.md
+++ b/BUGS.md
@@ -1,0 +1,48 @@
+# Wingnut Bug Findings — Code Review 2026-05-07
+
+## Critical
+
+### BUG-1: `scopeWrapper` passes `next` to scope handlers — double `next()` calls
+- **File:** `src/lib/index.ts:446-455`
+- **Status:** 🔧 In Progress
+- **Branch:** `bugfix/BUG-1-scope-wrapper-double-next`
+- Every `ScopeHandler` receives Express `next` as its 3rd argument. If a scope handler both returns `true` AND calls `next()`, the middleware chain advances twice. Since `some()` passes `next` to every scope until one returns `true`, a failing scope handler could also call `next()` prematurely.
+- **Impact:** Duplicate handler execution, double responses, or "headers already sent" errors.
+
+### BUG-2: `paths()` duplicate detection only checks the first method of a PathObject
+- **File:** `src/lib/index.ts:363-367`
+- **Status:** 📋 Pending
+- `Object.keys(item[path])[0]` only inspects the first HTTP method. Additional methods bypass the duplicate check.
+- **Impact:** Silent route conflicts, undefined routing behavior.
+
+### BUG-3: `authPathOp` only applies security to the first method
+- **File:** `src/lib/index.ts:542-553`
+- **Status:** 📋 Pending
+- `const [[method, operation]] = Object.entries(pathObject)` destructures only the first entry. Remaining methods are silently unprotected (dropped from returned PathObject).
+- **Impact:** Security middleware silently not applied to additional methods.
+
+### BUG-4: Schema cache key collision via `$id` — wrong validator returned
+- **File:** `src/lib/index.ts:141-148`
+- **Status:** 📋 Pending
+- Two structurally different schemas with the same `$id` produce the same cache key, returning the wrong compiled validator.
+- **Impact:** Incorrect request validation — bad data passes, valid data rejected.
+
+## Medium
+
+### BUG-5: `Object.assign` in `paths()` silently overwrites routes
+- **File:** `src/lib/index.ts:375`
+- **Status:** 📋 Pending
+- If two controllers produce PathItems with overlapping path keys, `Object.assign(acc.out, item)` silently overwrites.
+- **Impact:** Lost route definitions.
+
+### BUG-6: `validateParams` shares param schema objects by reference
+- **File:** `src/lib/index.ts:74`
+- **Status:** 📋 Pending
+- `schema.properties[param.name] = param.schema` is a direct reference. AJV may mutate schemas during compilation, contaminating shared Parameter objects across routes.
+- **Impact:** Cross-route schema contamination.
+
+### BUG-7: `param()` spread allows `in` to be overridden at runtime
+- **File:** `src/lib/index.ts:558-563`
+- **Status:** 📋 Pending
+- `Omit<Parameter, 'in'>` only protects at compile time. At runtime, an object with `in` property would override the intended param location.
+- **Impact:** Wrong validation target (e.g., body instead of query).

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -448,7 +448,7 @@ export const method =
 export const scopeWrapper =
   (cb: RequestHandler, scopes: ScopeHandler[]) =>
   (req: Request, res: Response, next: NextFunction) => {
-    const isAuthorized = scopes.some((v) => v(req, res, next))
+    const isAuthorized = scopes.some((v) => v(req, res))
     if (isAuthorized) {
       next()
     } else {

--- a/src/tests/all.test.ts
+++ b/src/tests/all.test.ts
@@ -925,6 +925,37 @@ describe('ScopeWrapper', () => {
     expect(cb).toHaveBeenCalledTimes(1)
     expect(next).not.toHaveBeenCalled()
   })
+
+  it('should not pass next to scope handlers — prevents double next()', () => {
+    const scopeThatAlsoCallsNext: ScopeHandler = (
+      _req: Request,
+      _res: Response,
+      next?: () => void,
+    ): boolean => {
+      next?.()
+      return true
+    }
+    const scopes = [scopeThatAlsoCallsNext]
+    scopeWrapper(cb, scopes)(req, res, next)
+    expect(next).toHaveBeenCalledTimes(1)
+    expect(cb).not.toHaveBeenCalled()
+  })
+
+  it('should not let a failing scope handler call next prematurely', () => {
+    const failingScopeThatCallsNext: ScopeHandler = (
+      _req: Request,
+      _res: Response,
+      next?: () => void,
+    ): boolean => {
+      next?.()
+      return false
+    }
+    const passingScope: ScopeHandler = (): boolean => true
+    const scopes = [failingScopeThatCallsNext, passingScope]
+    scopeWrapper(cb, scopes)(req, res, next)
+    expect(next).toHaveBeenCalledTimes(1)
+    expect(cb).not.toHaveBeenCalled()
+  })
 })
 
 describe('asyncWrapper', () => {


### PR DESCRIPTION
Scope handlers that both returned true and called next() caused double middleware chain advancement. The fix stops passing next to scope handlers — they are pure authorization checks that should only return a boolean.

Added two tests proving the bug (next called twice before fix) and proving the fix (next called exactly once after).