### PR TITLE
fix: paths() duplicate detection checks all methods, not just the first

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -4,14 +4,15 @@
 
 ### BUG-1: `scopeWrapper` passes `next` to scope handlers — double `next()` calls
 - **File:** `src/lib/index.ts:446-455`
-- **Status:** 🔧 In Progress
+- **Status:** ✅ Fixed (merged via #59)
 - **Branch:** `bugfix/BUG-1-scope-wrapper-double-next`
 - Every `ScopeHandler` receives Express `next` as its 3rd argument. If a scope handler both returns `true` AND calls `next()`, the middleware chain advances twice. Since `some()` passes `next` to every scope until one returns `true`, a failing scope handler could also call `next()` prematurely.
 - **Impact:** Duplicate handler execution, double responses, or "headers already sent" errors.
 
 ### BUG-2: `paths()` duplicate detection only checks the first method of a PathObject
 - **File:** `src/lib/index.ts:363-367`
-- **Status:** 📋 Pending
+- **Status:** 🔧 In Progress
+- **Branch:** `bugfix/BUG-2-paths-duplicate-detection-first-method-only`
 - `Object.keys(item[path])[0]` only inspects the first HTTP method. Additional methods bypass the duplicate check.
 - **Impact:** Silent route conflicts, undefined routing behavior.
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -365,12 +365,14 @@ export const wingnut = (ajv: AjvLike) => {
       const p = c(router)
       p.forEach((item) => {
         const path = Object.keys(item)[0]
-        const method = Object.keys(item[path])[0]
-        const full = `${method} ${path}`
-        if (acc.track.has(full)) {
-          throw new Error(`WingnutError: ${full} already exists`)
+        const methods = Object.keys(item[path])
+        for (const method of methods) {
+          const full = `${method} ${path}`
+          if (acc.track.has(full)) {
+            throw new Error(`WingnutError: ${full} already exists`)
+          }
+          acc.track.add(full)
         }
-        acc.track.add(full)
         Object.assign(acc.out, item)
       })
     })

--- a/src/tests/all.test.ts
+++ b/src/tests/all.test.ts
@@ -510,6 +510,57 @@ describe('integration tests', () => {
     )
   })
 
+  it('should detect duplicate paths across all methods, not just the first', () => {
+    const app = express()
+    const { route, paths, controller } = wingnut(ajv)
+
+    // First controller: registers GET and POST on /api/users
+    const ctrl1 = controller({
+      prefix: '/api',
+      route: (router: Router) =>
+        route(
+          router,
+          path(
+            '/users',
+            getMethod({
+              middleware: [
+                (_req: Request, res: Response) => res.status(200).send('get'),
+              ],
+            }),
+            postMethod({
+              middleware: [
+                (_req: Request, res: Response) => res.status(200).send('post'),
+              ],
+            }),
+          ),
+        ),
+    })
+
+    // Second controller: registers POST on same path — should be caught as duplicate
+    const ctrl2 = controller({
+      prefix: '/api',
+      route: (router: Router) =>
+        route(
+          router,
+          path(
+            '/users',
+            postMethod({
+              middleware: [
+                (_req: Request, res: Response) => res.status(200).send('post2'),
+              ],
+            }),
+          ),
+        ),
+    })
+
+    // GET /api/users from ctrl1 is the first method in the merged PathObject.
+    // POST /api/users appears in both but was not detected because only
+    // Object.keys(item[path])[0] was checked.
+    expect(() => paths(app, ctrl1, ctrl2)).toThrow(
+      'WingnutError: post /api/users already exists',
+    )
+  })
+
   it('should handle path operations with null middleware', async () => {
     const { route, paths, controller } = wingnut(ajv)
 


### PR DESCRIPTION
Previously only Object.keys(item[path])[0] was checked, so duplicate route registrations for non-first methods (e.g. POST when GET was first in a merged PathObject) were silently allowed.

The fix iterates all methods in each PathObject and tracks every method+path combination.

Added test proving the bug (duplicate POST on same path was not caught) and proving the fix (throws as expected).