### PR TITLE
fix: authPathOp applies security to all methods in a PathObject

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -11,14 +11,15 @@
 
 ### BUG-2: `paths()` duplicate detection only checks the first method of a PathObject
 - **File:** `src/lib/index.ts:363-367`
-- **Status:** 🔧 In Progress
+- **Status:** ✅ Fixed (merged via PR #60)
 - **Branch:** `bugfix/BUG-2-paths-duplicate-detection-first-method-only`
 - `Object.keys(item[path])[0]` only inspects the first HTTP method. Additional methods bypass the duplicate check.
 - **Impact:** Silent route conflicts, undefined routing behavior.
 
 ### BUG-3: `authPathOp` only applies security to the first method
 - **File:** `src/lib/index.ts:542-553`
-- **Status:** 📋 Pending
+- **Status:** 🔧 In Progress
+- **Branch:** `bugfix/BUG-3-authpathop-only-secures-first-method`
 - `const [[method, operation]] = Object.entries(pathObject)` destructures only the first entry. Remaining methods are silently unprotected (dropped from returned PathObject).
 - **Impact:** Security middleware silently not applied to additional methods.
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -546,14 +546,16 @@ export const scope = <T = string>(
 export const authPathOp =
   (scope: ScopeObject) =>
   (pathObject: PathObject): PathObject => {
-    const [[method, operation]] = Object.entries(pathObject)
-    const newOperation: PathOperation = {
-      ...operation,
-      security: [{ [scope.auth]: scope.scopes }],
-      scope: [scope],
-      responses: { ...operation.responses, ...scope.responses },
+    const result: PathObject = {}
+    for (const [method, operation] of Object.entries(pathObject)) {
+      ;(result as Record<string, PathOperation>)[method] = {
+        ...operation,
+        security: [{ [scope.auth]: scope.scopes }],
+        scope: [scope],
+        responses: { ...operation.responses, ...scope.responses },
+      }
     }
-    return { [method]: newOperation }
+    return result
   }
 
 /**

--- a/src/tests/all.test.ts
+++ b/src/tests/all.test.ts
@@ -708,6 +708,43 @@ describe('Security Schema', () => {
       },
     })
   })
+
+  it('should apply security to all methods in a multi-method PathObject', () => {
+    const auth: Security = {
+      name: 'auth',
+      handler: (_req: Request, res: Response) => {
+        res.status(400).send('Not Auth')
+      },
+      scopes: {
+        admin: UserLevel(100),
+      },
+      responses: {
+        '400': {
+          description: 'Not Auth',
+        },
+      },
+    }
+
+    const adminAuth = authPathOp(scope(auth, 'admin'))
+
+    // Pass a PathObject with multiple methods
+    const actual = adminAuth({
+      get: {
+        middleware: [routeHandler],
+        responses: { '200': { description: 'Get success' } },
+      },
+      post: {
+        middleware: [routeHandler],
+        responses: { '201': { description: 'Created' } },
+      },
+    })
+
+    // Both methods should have security applied
+    expect(actual?.get?.security).toStrictEqual([{ auth: ['admin'] }])
+    expect(actual?.get?.scope).toBeDefined()
+    expect(actual?.post?.security).toStrictEqual([{ auth: ['admin'] }])
+    expect(actual?.post?.scope).toBeDefined()
+  })
   it('should call the error middleware if provided', async () => {
     const app = express()
     const { route, paths, controller } = wingnut(ajv)


### PR DESCRIPTION
Previously authPathOp destructured only the first Object.entries() result, so multi-method PathObjects (e.g. { get: ..., post: ... }) had security applied to only the first method — the rest were silently unprotected.

The fix iterates all entries in the PathObject and applies the security scope to each method.

Added test proving the bug (POST was missing security after authPathOp) and proving the fix (both GET and POST have security applied).