### PR TITLE
fix: schema cache uses structural key instead of $id alone

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -18,14 +18,15 @@
 
 ### BUG-3: `authPathOp` only applies security to the first method
 - **File:** `src/lib/index.ts:542-553`
-- **Status:** 🔧 In Progress
+- **Status:** ✅ Fixed (merged via PR #61)
 - **Branch:** `bugfix/BUG-3-authpathop-only-secures-first-method`
 - `const [[method, operation]] = Object.entries(pathObject)` destructures only the first entry. Remaining methods are silently unprotected (dropped from returned PathObject).
 - **Impact:** Security middleware silently not applied to additional methods.
 
 ### BUG-4: Schema cache key collision via `$id` — wrong validator returned
 - **File:** `src/lib/index.ts:141-148`
-- **Status:** 📋 Pending
+- **Status:** 🔧 In Progress
+- **Branch:** `bugfix/BUG-4-schema-cache-id-collision`
 - Two structurally different schemas with the same `$id` produce the same cache key, returning the wrong compiled validator.
 - **Impact:** Incorrect request validation — bad data passes, valid data rejected.
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -139,11 +139,6 @@ export const createSchemaCache = () => {
   let misses = 0
 
   const generateCacheKey = (schema: AjvLikeSchemaObject): string => {
-    // Use schema.$id if available, otherwise stringify the schema
-    if (schema.$id) {
-      return schema.$id
-    }
-    // Create a stable string representation for caching
     return JSON.stringify(schema)
   }
 

--- a/src/tests/all.test.ts
+++ b/src/tests/all.test.ts
@@ -1733,26 +1733,28 @@ describe('createSchemaCache', () => {
     expect(result).toBeUndefined()
   })
 
-  it('should use $id for cache key when available', () => {
+  it('should cache schemas by structure, not by $id alone', () => {
     const cache = createSchemaCache()
     const mockValidator1 = vi.fn().mockReturnValue(true)
+    const mockValidator2 = vi.fn().mockReturnValue(false)
 
-    const schemaWithId = {
-      $id: 'unique-id',
+    const schemaA = {
+      $id: 'shared-id',
       type: 'string' as const,
     }
 
-    const sameIdDifferentSchema = {
-      $id: 'unique-id',
-      type: 'number' as const, // Different type but same $id
+    const schemaB = {
+      $id: 'shared-id',
+      type: 'number' as const,
     }
 
-    // Set with first schema
-    cache.set(schemaWithId, mockValidator1)
+    cache.set(schemaA, mockValidator1)
+    cache.set(schemaB, mockValidator2)
 
-    // Get with different schema but same $id - should return same validator
-    const result = cache.get(sameIdDifferentSchema)
-    expect(result).toBe(mockValidator1)
+    // Same $id but different structure — must return the correct validator
+    expect(cache.get(schemaA)).toBe(mockValidator1)
+    expect(cache.get(schemaB)).toBe(mockValidator2)
+    expect(cache.getStats().size).toBe(2)
   })
 
   it('should use JSON.stringify for cache key when $id is not available', () => {


### PR DESCRIPTION
Two structurally different schemas sharing the same $id produced the same cache key, causing the wrong compiled validator to be returned. This could let invalid data pass validation or reject valid data.

The fix always uses JSON.stringify(schema) as the cache key, ensuring structurally different schemas always get separate cache entries.

Updated the existing test that incorrectly asserted $id-only caching to verify that different schemas with the same $id are cached separately.