### PR TITLE
ci: modernize GitHub Actions, add dependabot config, drop Node 18 target

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  # Enable version updates for npm
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "build(deps)"
+      include: "scope"
+
+  # Enable version updates for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "ci(deps)"
+      include: "scope"

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -15,30 +15,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           registry-url: 'https://registry.npmjs.org'
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v2.4.1
-
-      - name: Cache pnpm
-        uses: actions/cache@v4
-        with:
-          path: ~/.pnpm-store
-          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-
-
-      - name: Install Biome
-        run: pnpm add -g @biomejs/biome
+          cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Build
         run: pnpm build
@@ -53,9 +43,9 @@ jobs:
         run: pnpm coverage
 
       - name: Publish code coverage report
-        uses: codecov/codecov-action@v3
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Publish to npm
         if: startsWith(github.ref, 'refs/tags/v')

--- a/package.json
+++ b/package.json
@@ -8,12 +8,15 @@
     "test": "vitest",
     "test:no-watch": "vitest --run",
     "coverage": "vitest run --coverage",
-    "build": "esbuild src/index.ts --bundle --platform=node --target=node18 --minify --tree-shaking=true --external:express --external:ajv --outdir=dist && tsc --project tsconfig.build.json",
+    "build": "esbuild src/index.ts --bundle --platform=node --target=node20 --minify --tree-shaking=true --external:express --external:ajv --outdir=dist && tsc --project tsconfig.build.json",
     "lint": "biome check --diagnostic-level=error",
     "lint:fix": "biome check --fix"
   },
   "author": "cawalch@pm.me",
   "license": "MIT",
+  "engines": {
+    "node": ">=20"
+  },
   "devDependencies": {
     "@biomejs/biome": "2.2.5",
     "@types/express": "^5.0.3",


### PR DESCRIPTION
## Summary

Chore PR grouping all CI/GHA modernization work (Jun 2026 review).

### GitHub Actions (all were stale)
| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | **v6** |
| `actions/setup-node` | v4 | **v6** |
| `pnpm/action-setup` | v2.4.1 | **v6** |
| `actions/cache` | v4 (separate step) | removed (uses setup-node built-in `cache: pnpm`) |
| `codecov/codecov-action` | v3 | **v5** |

`v2`/`v3` actions ran on the deprecated Node 16 runtime and trigger workflow warnings.

### Other CI changes
- **Add `.github/dependabot.yml`** covering `npm` **and** `github-actions` ecosystems. GHA was previously untracked (only npm bumps landed via UI config), which is why all 5 actions drifted ~4 majors behind.
- Remove redundant `pnpm add -g @biomejs/biome` step (Biome is already a devDependency).
- Switch `pnpm install` → `pnpm install --frozen-lockfile` (CI-safe).

### Node target fix
- esbuild `--target=node18` → `node20` (Node 18 EOL'd Apr 2025).
- Add `engines: { node: ">=20" }` to match the vitest/runtime floor.

## Risk
Low — no source changes. CI behavior change is the frozen-lockfile + built-in pnpm cache.
