### PR TITLE
fix: BUG-5/6/7 — path-merge, schema-ref, param-override

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -25,7 +25,7 @@
 
 ### BUG-4: Schema cache key collision via `$id` — wrong validator returned
 - **File:** `src/lib/index.ts:141-148`
-- **Status:** 🔧 In Progress
+- **Status:** ✅ Fixed (merged via #62)
 - **Branch:** `bugfix/BUG-4-schema-cache-id-collision`
 - Two structurally different schemas with the same `$id` produce the same cache key, returning the wrong compiled validator.
 - **Impact:** Incorrect request validation — bad data passes, valid data rejected.
@@ -34,18 +34,18 @@
 
 ### BUG-5: `Object.assign` in `paths()` silently overwrites routes
 - **File:** `src/lib/index.ts:375`
-- **Status:** 📋 Pending
+- **Status:** ✅ Fixed (merged via #80)
 - If two controllers produce PathItems with overlapping path keys, `Object.assign(acc.out, item)` silently overwrites.
 - **Impact:** Lost route definitions.
 
 ### BUG-6: `validateParams` shares param schema objects by reference
 - **File:** `src/lib/index.ts:74`
-- **Status:** 📋 Pending
+- **Status:** ✅ Fixed (merged via #80)
 - `schema.properties[param.name] = param.schema` is a direct reference. AJV may mutate schemas during compilation, contaminating shared Parameter objects across routes.
 - **Impact:** Cross-route schema contamination.
 
 ### BUG-7: `param()` spread allows `in` to be overridden at runtime
 - **File:** `src/lib/index.ts:558-563`
-- **Status:** 📋 Pending
+- **Status:** ✅ Fixed (merged via #80)
 - `Omit<Parameter, 'in'>` only protects at compile time. At runtime, an object with `in` property would override the intended param location.
 - **Impact:** Wrong validation target (e.g., body instead of query).

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -69,9 +69,9 @@ export const validateParams = (
       continue
     }
 
-    // Direct assignment - param.schema is not mutated after this point
-    // This avoids unnecessary object spread allocation
-    schema.properties[param.name] = param.schema
+    // Copy the param schema so AJV cannot mutate a shared Parameter object
+    // across routes during compilation.
+    schema.properties[param.name] = { ...param.schema }
 
     if (param.required) {
       required.add(param.name)
@@ -354,7 +354,7 @@ export const wingnut = (ajv: AjvLike) => {
     router: Router,
     ...ctrls: ReturnType<typeof controller>[]
   ): PathItem => {
-    const acc = { out: {}, track: new Set<string>() }
+    const acc = { out: {} as PathItem, track: new Set<string>() }
 
     ctrls.forEach((c) => {
       const p = c(router)
@@ -368,7 +368,9 @@ export const wingnut = (ajv: AjvLike) => {
           }
           acc.track.add(full)
         }
-        Object.assign(acc.out, item)
+        // Merge methods under the same path key; the duplicate check above
+        // guarantees the method sets are disjoint, so none are overwritten.
+        acc.out[path] = Object.assign(acc.out[path] ?? {}, item[path])
       })
     })
 
@@ -572,8 +574,8 @@ export const authPathOp =
 export const param =
   (pin: ParamIn) =>
   (param: Omit<Parameter, 'in'>): Parameter => ({
-    in: pin,
     ...param,
+    in: pin,
   })
 
 export const integer = (sch: Partial<ParamSchema>): ParamSchema => ({

--- a/src/tests/all.test.ts
+++ b/src/tests/all.test.ts
@@ -137,7 +137,7 @@ describe('validateParams', () => {
     })
   })
 
-  it('should not share param schema references (BUG-6)', () => {
+  it('should not share param schema references', () => {
     const sharedSchema = { type: 'integer' as const, minimum: 1 }
     const params: (Partial<Parameter> & { name: string })[] = [
       { in: 'query', name: 'limit', schema: sharedSchema },
@@ -153,7 +153,7 @@ describe('validateParams', () => {
 })
 
 describe('param', () => {
-  it('should not let `in` be overridden at runtime (BUG-7)', () => {
+  it('should not let `in` be overridden at runtime', () => {
     const result = queryParam({
       name: 'limit',
       in: 'body',
@@ -683,7 +683,7 @@ describe('integration tests', () => {
     expect(widgetCalled).toBe(1)
   })
 
-  it('should merge methods under the same path across controllers (BUG-5)', () => {
+  it('should merge methods under the same path across controllers', () => {
     const app = express()
     const { route, paths, controller } = wingnut(ajv)
     const ctrl1 = controller({

--- a/src/tests/all.test.ts
+++ b/src/tests/all.test.ts
@@ -136,6 +136,31 @@ describe('validateParams', () => {
       required: [],
     })
   })
+
+  it('should not share param schema references (BUG-6)', () => {
+    const sharedSchema = { type: 'integer' as const, minimum: 1 }
+    const params: (Partial<Parameter> & { name: string })[] = [
+      { in: 'query', name: 'limit', schema: sharedSchema },
+      { in: 'query', name: 'offset', schema: sharedSchema },
+    ]
+    const result = validateParams(params)
+    // AJV may mutate compiled schemas; the built schema must not reference
+    // the input object, or a shared Parameter contaminates other routes.
+    expect(result.properties?.limit).not.toBe(sharedSchema)
+    expect(result.properties?.offset).not.toBe(sharedSchema)
+    expect(result.properties?.limit).toEqual(sharedSchema)
+  })
+})
+
+describe('param', () => {
+  it('should not let `in` be overridden at runtime (BUG-7)', () => {
+    const result = queryParam({
+      name: 'limit',
+      in: 'body',
+      schema: { type: 'integer' as const },
+    } as unknown as Omit<Parameter, 'in'>)
+    expect(result.in).toBe('query')
+  })
 })
 
 describe('validateBuilder', () => {
@@ -656,6 +681,45 @@ describe('integration tests', () => {
     await request(app).get('/widgets').expect(200)
     expect(usersCalled).toBe(1)
     expect(widgetCalled).toBe(1)
+  })
+
+  it('should merge methods under the same path across controllers (BUG-5)', () => {
+    const app = express()
+    const { route, paths, controller } = wingnut(ajv)
+    const ctrl1 = controller({
+      prefix: '/api',
+      route: (router: Router) =>
+        route(
+          router,
+          path(
+            '/users',
+            getMethod({
+              middleware: [
+                (_req: Request, res: Response) => res.status(200).send('get'),
+              ],
+            }),
+          ),
+        ),
+    })
+    const ctrl2 = controller({
+      prefix: '/api',
+      route: (router: Router) =>
+        route(
+          router,
+          path(
+            '/users',
+            postMethod({
+              middleware: [
+                (_req: Request, res: Response) => res.status(200).send('post'),
+              ],
+            }),
+          ),
+        ),
+    })
+    const doc = paths(app, ctrl1, ctrl2)
+    // both methods must survive in the aggregated PathItem
+    expect(doc['/api/users'].get).toBeDefined()
+    expect(doc['/api/users'].post).toBeDefined()
   })
 })
 


### PR DESCRIPTION
## Summary

Closes the three remaining pending bugs from the 2026-05-07 code review (BUG-5, BUG-6, BUG-7), each with a regression test written first (TDD). Also corrects a stale BUGS.md status entry (BUG-4 was marked "In Progress" but is already merged via #62).

## BUG-6 — `validateParams` shares param schema objects by reference

```ts
// before
schema.properties[param.name] = param.schema
```

The inline comment claimed "param.schema is not mutated after this point" — **that is incorrect**. AJV mutates schemas during `compile()` (adds `$id`/`_$ref`, and with options like `removeAdditional`, `coerceTypes`, `useDefaults` mutates at validate time too). A shared `Parameter` object — e.g. one schema reused for `limit` and `offset` across routes — gets contaminated.

**Fix:** shallow-copy the param schema. The "avoids unnecessary object spread allocation" rationale was premature optimization on a per-route-build path (not a hot request path).

## BUG-5 — `paths()` `Object.assign` overwrites at path level

Two controllers producing the **same path with different methods** lost methods in the aggregated `PathItem` (used for Swagger docs). The BUG-2 duplicate check tracks `method+path`, but `Object.assign(acc.out, item)` overwrote at the path key.

**Fix:** merge methods under the path key. The duplicate check guarantees the method sets are disjoint, so no method overwrites another:
```ts
acc.out[path] = Object.assign(acc.out[path] ?? {}, item[path])
```

## BUG-7 — `param()` spread order lets `in` be overridden

```ts
// before
({ in: pin, ...param })   // a runtime `in` on param overrides pin
// after
({ ...param, in: pin })   // builder location always wins
```

`Omit<Parameter, 'in'>` is only a compile-time guard. Reordering the spread is defense-in-depth so the builder's location is authoritative at runtime.

## Verification

All three bugs reproduced as failing tests first, then fixed:
- `pnpm build` ✅
- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `pnpm test` ✅ (62/62 — was 59; +3 regression tests)
