### PR TITLE
feat(security): emit securitySchemes + model 401/403 (ROADMAP Layer 0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ import {
   scope,
   Security,
   authPathOp,
+  securitySchemes,
   ScopeHandler,
   putMethod,
   ParamSchema,
@@ -202,24 +203,31 @@ const userLevelAuth =
   (req: UserAuth): boolean =>
     (req.user?.level ?? 0) >= minLevel;
 
-// Build Authorization Security object
+// A Security definition: enforcement middleware + OpenAPI docs in one place,
+// so the guards and the documentation cannot drift.
 const auth: Security = {
-  name: "user level authorization",
-  // handler if user is not authenticated
-  handler: (_req: Request, res: Response) => {
-    res.status(400).send("Not Authorized");
+  // name is the securityScheme key each operation references
+  name: "bearerAuth",
+  // OpenAPI securityScheme, emitted into components.securitySchemes
+  scheme: { type: "http", scheme: "bearer", bearerFormat: "JWT" },
+  // optional 401 handler — invoked when authentication fails
+  // (missing/invalid token). Verify the token in a `before` hook.
+  unauthorized: (_req: Request, res: Response) => {
+    res.status(401).send("Unauthenticated");
+  },
+  // 403 handler — invoked when authenticated but the scope check fails
+  forbidden: (_req: Request, res: Response) => {
+    res.status(403).send("Forbidden");
   },
   scopes: {
-    // define OpenAPI security scopes based on user levels
-    // these can be referenced with wingnut's Scope
+    // OpenAPI security scopes, evaluated with OR semantics
     admin: userLevelAuth(100),
     user: userLevelAuth(10),
   },
-  // response schema for authorization failure
+  // response schemas surfaced on each secured operation
   responses: {
-    "400": {
-      description: "Not Authorized",
-    },
+    "401": { description: "Unauthenticated" },
+    "403": { description: "Forbidden" },
   },
 };
 
@@ -257,11 +265,21 @@ const editUserAPI = adminAuth(
       },
     },
     middleware: [
-      // express.js RequestHandler requires admin authentication now
+      // express.js RequestHandler — admin-scoped automatically
     ],
   }),
 );
+
+// Emit components.securitySchemes so per-operation security references
+// resolve in Swagger UI / Redoc / Schemathesis. Securities without a
+// scheme are skipped.
+const schemes = securitySchemes(auth);
+// → { bearerAuth: { type: "http", scheme: "bearer", bearerFormat: "JWT" } }
 ```
+
+Wingnut ships **no** JWT/OAuth/session library — bring your own crypto. Verify
+the token in a `before` hook and populate `req.user`; wingnut only composes
+the middleware and documents the scheme.
 
 ## Type-Safe Request Values
 
@@ -362,11 +380,14 @@ type Body = WnDataType<{
 ```typescript
 import express from 'express';
 import Ajv from 'ajv';
-import { PathItem, wingnut } from 'wingnut';
+import { PathItem, wingnut, securitySchemes, Security } from 'wingnut';
 import swaggerUI from 'swagger-ui-express';
 
 const ajv = new Ajv();
 ajv.opts.coerceTypes = true;
+
+// `auth` is the Security definition from "Secure Routes with Scopes"
+const securities: Security[] = [auth];
 
 // base swagger document
 const swaggerPath = (paths: PathItem) => ({
@@ -377,6 +398,7 @@ const swaggerPath = (paths: PathItem) => ({
     description: 'My App Swagger Doc',
   },
   paths,
+  components: { securitySchemes: securitySchemes(...securities) },
 })
 
 const { route, paths, controller } = wingnut(ajv)

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -24,6 +24,8 @@ import {
   PathOperation,
   ScopeHandler,
   ScopeObject,
+  SecuritySchemeObject,
+  SecuritySchemesObject,
 } from '../types/open-api-3'
 import { ValidationError } from './errors'
 
@@ -36,8 +38,30 @@ export type ValidateByParam = Record<
 
 export interface Security<S = string> {
   name: string
+  /**
+   * OpenAPI Security Scheme documentation for this definition. Emitted into
+   * `components.securitySchemes` by `securitySchemes()` so per-operation
+   * `security` references resolve in Swagger UI / Redoc / Schemathesis.
+   */
+  scheme?: SecuritySchemeObject
+  /**
+   * Credential-extraction / pre-authorization hook (e.g. parse + verify a
+   * token and populate `req.user`). Runs before scope evaluation.
+   */
   before?: RequestHandler
-  handler: RequestHandler
+  /**
+   * Unauthenticated (401) handler. Invoked when credential extraction
+   * reports a missing or invalid credential — e.g. a Layer 1 `bearerAuth`
+   * `verify` returning `false`. Optional at Layer 0: when omitted, `before`
+   * owns its own failure response.
+   */
+  unauthorized?: RequestHandler
+  /**
+   * Forbidden (403) handler. Invoked when the caller is authenticated but
+   * lacks every required scope. Replaces the legacy `handler` field so the
+   * 401/403 distinction is explicit on the definition.
+   */
+  forbidden: RequestHandler
   scopes: NamedHandler<S>
   responses?: MediaSchemaItem
 }
@@ -486,22 +510,25 @@ export const scopeWrapper =
  * // authorization middleware based on user level
  * const userLevel = (minLevel: number): ScopeHandler => (
  *    req: UserAuth
- * ): boolean => req.user.level > minLevel
+ * ): boolean => (req.user?.level ?? 0) > minLevel
  *
+ * // authorization security definition
  * const auth: Security = {
  *  name: 'auth',
- *  handler: (_req: Request, res: Response) => {
- *    // unauthorized handler
- *    res.status(400).send('Not Auth')
+ *  // OpenAPI security scheme doc, emitted into components.securitySchemes
+ *  scheme: { type: 'http', scheme: 'bearer', bearerFormat: 'JWT' },
+ *  // 403 forbidden handler (authenticated but missing scope)
+ *  forbidden: (_req: Request, res: Response) => {
+ *    res.status(403).send('Forbidden')
  *  },
  *  scopes: {
  *    admin: userLevel(100),
  *    moderator: userLevel(50)
  *  },
  *  responses: {
- *  '400': {
- *    description: 'Not Auth'
- *   }
+ *    '403': {
+ *      description: 'Forbidden'
+ *    }
  *  }
  * }
  *
@@ -528,7 +555,7 @@ export const scope = <T = string>(
     scopes,
     middleware: [
       ...(security.before ? [security.before] : []),
-      scopeWrapper(security.handler, scopeMiddlewares),
+      scopeWrapper(security.forbidden, scopeMiddlewares),
     ],
     responses: security.responses,
   }
@@ -567,6 +594,43 @@ export const authPathOp =
     }
     return result
   }
+
+/**
+ * securitySchemes
+ *
+ * Build the OpenAPI `components.securitySchemes` map from one or more
+ * `Security` definitions, keyed by `security.name`. Securities without a
+ * `scheme` are skipped, so per-operation `security` references resolve to a
+ * real scheme definition in the served spec (Swagger UI, Redoc, Schemathesis).
+ *
+ * ```typescript
+ * const auth: Security = {
+ *   name: 'bearerAuth',
+ *   scheme: { type: 'http', scheme: 'bearer', bearerFormat: 'JWT' },
+ *   forbidden: (_req, res) => res.status(403).send('Forbidden'),
+ *   scopes: { admin: (req) => (req.user?.level ?? 0) >= 100 },
+ *   responses: { '403': { description: 'Forbidden' } },
+ * }
+ *
+ * const spec = {
+ *   openapi: '3.0.0',
+ *   info: { version: '1.0.0', title: 'API' },
+ *   paths,
+ *   components: { securitySchemes: securitySchemes(auth) },
+ * }
+ * ```
+ */
+export const securitySchemes = (
+  ...securities: Security[]
+): SecuritySchemesObject => {
+  const schemes: SecuritySchemesObject = {}
+  for (const security of securities) {
+    if (security.scheme) {
+      schemes[security.name] = security.scheme
+    }
+  }
+  return schemes
+}
 
 /**
  * Create a parameter schema with the given `in` location.

--- a/src/tests/all.test.ts
+++ b/src/tests/all.test.ts
@@ -22,6 +22,7 @@ import {
   Security,
   scope,
   scopeWrapper,
+  securitySchemes,
   validateBuilder,
   validateParams,
 } from '../lib/index'
@@ -741,15 +742,15 @@ describe('Security Schema', () => {
   it('should scope request to a user level', () => {
     const auth: Security = {
       name: 'auth',
-      handler: (_req: Request, res: Response) => {
-        res.status(400).send('Not Auth')
+      forbidden: (_req: Request, res: Response) => {
+        res.status(403).send('Forbidden')
       },
       scopes: {
         admin: UserLevel(100),
       },
       responses: {
-        '400': {
-          description: 'Not Auth',
+        '403': {
+          description: 'Forbidden',
         },
       },
     }
@@ -774,8 +775,8 @@ describe('Security Schema', () => {
       '200': {
         description: 'Success',
       },
-      '400': {
-        description: 'Not Auth',
+      '403': {
+        description: 'Forbidden',
       },
     })
   })
@@ -783,15 +784,15 @@ describe('Security Schema', () => {
   it('should apply security to all methods in a multi-method PathObject', () => {
     const auth: Security = {
       name: 'auth',
-      handler: (_req: Request, res: Response) => {
-        res.status(400).send('Not Auth')
+      forbidden: (_req: Request, res: Response) => {
+        res.status(403).send('Forbidden')
       },
       scopes: {
         admin: UserLevel(100),
       },
       responses: {
-        '400': {
-          description: 'Not Auth',
+        '403': {
+          description: 'Forbidden',
         },
       },
     }
@@ -946,15 +947,15 @@ describe('Security Schema', () => {
         calledBefore = true
         next()
       },
-      handler: (_req: Request, res: Response) => {
-        res.status(400).send('Not Auth')
+      forbidden: (_req: Request, res: Response) => {
+        res.status(403).send('Forbidden')
       },
       scopes: {
         admin: UserLevel(100),
       },
       responses: {
-        '400': {
-          description: 'Not Auth',
+        '403': {
+          description: 'Forbidden',
         },
       },
     }
@@ -1000,15 +1001,15 @@ describe('Security Schema', () => {
   it('should throw error when scope does not exist', () => {
     const security: Security = {
       name: 'auth',
-      handler: (_req: Request, res: Response) => {
-        res.status(400).send('Not Auth')
+      forbidden: (_req: Request, res: Response) => {
+        res.status(403).send('Forbidden')
       },
       scopes: {
         admin: () => true,
       },
       responses: {
-        '400': {
-          description: 'Not Auth',
+        '403': {
+          description: 'Forbidden',
         },
       },
     }
@@ -1031,16 +1032,16 @@ describe('Security Schema', () => {
       })
     const security: Security = {
       name: 'auth',
-      handler: (_req: Request, res: Response) => {
-        res.status(400).send('Not Auth')
+      forbidden: (_req: Request, res: Response) => {
+        res.status(403).send('Forbidden')
       },
       scopes: {
         admin: () => true,
         moderator: () => true,
       },
       responses: {
-        '400': {
-          description: 'Not Auth',
+        '403': {
+          description: 'Forbidden',
         },
       },
     }
@@ -1055,6 +1056,102 @@ describe('Security Schema', () => {
     expect(consoleSpyError).not.toHaveBeenCalled()
 
     consoleSpyError.mockRestore()
+  })
+})
+
+describe('securitySchemes', () => {
+  it('emits components.securitySchemes keyed by Security.name', () => {
+    const bearer: Security = {
+      name: 'bearerAuth',
+      scheme: { type: 'http', scheme: 'bearer', bearerFormat: 'JWT' },
+      forbidden: (_req: Request, res: Response) => {
+        res.status(403).send('Forbidden')
+      },
+      scopes: { admin: () => true },
+    }
+    const key: Security = {
+      name: 'apiKey',
+      scheme: { type: 'apiKey', in: 'header', name: 'X-API-Key' },
+      forbidden: (_req: Request, res: Response) => {
+        res.status(403).send('Forbidden')
+      },
+      scopes: { admin: () => true },
+    }
+    expect(securitySchemes(bearer, key)).toStrictEqual({
+      bearerAuth: {
+        type: 'http',
+        scheme: 'bearer',
+        bearerFormat: 'JWT',
+      },
+      apiKey: { type: 'apiKey', in: 'header', name: 'X-API-Key' },
+    })
+  })
+
+  it('skips Security definitions without a scheme', () => {
+    const docless: Security = {
+      name: 'docless',
+      forbidden: (_req: Request, res: Response) => {
+        res.status(403).send('Forbidden')
+      },
+      scopes: { admin: () => true },
+    }
+    expect(securitySchemes(docless)).toStrictEqual({})
+  })
+
+  it('resolves per-operation security refs against the emitted map', () => {
+    // The auth name on a Security must be a key in components.securitySchemes
+    // so Swagger UI / Redoc / Schemathesis can render the requirement.
+    const auth: Security = {
+      name: 'bearerAuth',
+      scheme: { type: 'http', scheme: 'bearer', bearerFormat: 'JWT' },
+      forbidden: (_req: Request, res: Response) => {
+        res.status(403).send('Forbidden')
+      },
+      scopes: { admin: () => true },
+      responses: { '403': { description: 'Forbidden' } },
+    }
+    const secured = authPathOp(scope(auth, 'admin'))(
+      getMethod({ middleware: [] }),
+    )
+    const schemes = securitySchemes(auth)
+    const refs = secured.get?.security ?? []
+    for (const ref of refs) {
+      for (const name of Object.keys(ref)) {
+        expect(schemes).toHaveProperty(name)
+      }
+    }
+  })
+})
+
+describe('401/403 modeling', () => {
+  it('scope() propagates both 401 and 403 responses', () => {
+    const auth: Security = {
+      name: 'bearerAuth',
+      scheme: { type: 'http', scheme: 'bearer' },
+      unauthorized: (_req: Request, res: Response) => {
+        res.status(401).send('Unauthenticated')
+      },
+      forbidden: (_req: Request, res: Response) => {
+        res.status(403).send('Forbidden')
+      },
+      scopes: { admin: () => false },
+      responses: {
+        '401': { description: 'Unauthenticated' },
+        '403': { description: 'Forbidden' },
+      },
+    }
+    const secured = authPathOp(scope(auth, 'admin'))(
+      getMethod({
+        middleware: [],
+        responses: { '200': { description: 'OK' } },
+      }),
+    )
+    expect(secured.get?.responses).toStrictEqual({
+      '200': { description: 'OK' },
+      '401': { description: 'Unauthenticated' },
+      '403': { description: 'Forbidden' },
+    })
+    expect(secured.get?.security).toStrictEqual([{ bearerAuth: ['admin'] }])
   })
 })
 

--- a/src/types/open-api-3.ts
+++ b/src/types/open-api-3.ts
@@ -18,15 +18,70 @@ export interface AppObject {
   components?: Components
 }
 
-interface Components {
-  securitySchemas: SecuritySchemesObject
+/**
+ * OpenAPI 3.0 Security Scheme Object.
+ * @see https://spec.openapis.org/oas/v3.0.3#security-scheme-object
+ */
+export type SecuritySchemeType = 'apiKey' | 'http' | 'oauth2' | 'openIdConnect'
+
+/**
+ * OpenAPI 3.0 OAuth Flows Object.
+ * @see https://spec.openapis.org/oas/v3.0.3#oauth-flows-object
+ */
+export interface OAuthFlowsObject {
+  implicit?: {
+    authorizationUrl: string
+    refreshUrl?: string
+    scopes: Record<string, string>
+  }
+  password?: {
+    tokenUrl: string
+    refreshUrl?: string
+    scopes: Record<string, string>
+  }
+  clientCredentials?: {
+    tokenUrl: string
+    refreshUrl?: string
+    scopes: Record<string, string>
+  }
+  authorizationCode?: {
+    authorizationUrl: string
+    tokenUrl: string
+    refreshUrl?: string
+    scopes: Record<string, string>
+  }
 }
 
-interface SecuritySchemesObject {
-  [y: string]: {
-    type: string
-    [z: string]: unknown
-  }
+/**
+ * OpenAPI 3.0 Security Scheme Object. Required fields depend on `type`
+ * (e.g. `name`/`in` for apiKey, `scheme` for http, `flows` for oauth2).
+ * @see https://spec.openapis.org/oas/v3.0.3#security-scheme-object
+ */
+export interface SecuritySchemeObject {
+  type: SecuritySchemeType
+  description?: string
+  /** Required when type === 'apiKey'. */
+  name?: string
+  /** Required when type === 'apiKey'. */
+  in?: 'query' | 'header' | 'cookie'
+  /** Required when type === 'http'. */
+  scheme?: string
+  /** Used together with http scheme 'bearer'. */
+  bearerFormat?: string
+  /** Required when type === 'oauth2'. */
+  flows?: OAuthFlowsObject
+  /** Required when type === 'openIdConnect'. */
+  openIdConnectUrl?: string
+}
+
+/**
+ * OpenAPI 3.0 `components.securitySchemes` map, keyed by scheme name.
+ * Per-operation `security` references must resolve to a key here.
+ */
+export type SecuritySchemesObject = Record<string, SecuritySchemeObject>
+
+interface Components {
+  securitySchemes: SecuritySchemesObject
 }
 
 export interface PathItem {


### PR DESCRIPTION
Implements **Layer 0** of the security-DSL roadmap (`docs/roadmap` PR) — the foundation fixes that unblock the authentication scheme builders (Layer 1). Independently shippable.

## What & why

Wingnut's differentiator is one `Security` definition → authorization middleware **and** OpenAPI `security` documentation. Today that wedge is ~40% built: the docs side is broken.

| Layer 0 deliverable | Before | After |
| --- | --- | --- |
| Spec field | `Components.securitySchemas` (typo — tools ignore it) | `Components.securitySchemes` |
| Scheme emission | never emitted; per-op `security` refs dangle | `securitySchemes(...securities)` emits `components.securitySchemes` from `Security.scheme` |
| Auth status model | `handler` + `400` (unauthorized vs forbidden conflated) | `forbidden` (403) + optional `unauthorized` (401) |

## Changes

- **`src/types/open-api-3.ts`** — rename `securitySchemas` → `securitySchemes`; replace the loose `{ type: string }` with spec-accurate OpenAPI 3.0 `SecuritySchemeObject`, `OAuthFlowsObject`, `SecuritySchemeType` (all exported).
- **`src/lib/index.ts`**
  - `Security`: add `scheme?: SecuritySchemeObject`, rename `handler` → `forbidden` (403), add `unauthorized?: RequestHandler` (401 slot, wired by Layer 1 `verify`).
  - `scope()`: uses `security.forbidden`; propagates whatever response codes the definition declares (`'401'`/`'403'`).
  - New `securitySchemes(...securities)` helper → `Record<string, SecuritySchemeObject>` keyed by `security.name`; schemeless securities skipped.
- **`src/tests/all.test.ts`** — 5 existing `Security` literals updated; **4 new tests** (scheme emission keyed by name, schemeless skip, per-op ref resolution, 401/403 response propagation). 66 pass.
- **`README.md`** — "Secure Routes with Scopes" now uses `bearerAuth` with `scheme`, `unauthorized`/`forbidden`, 401/403 responses, and shows `securitySchemes()`; Swagger section wires `components.securitySchemes`; added the bring-your-own-crypto note.

## Integrity constraints (from ROADMAP)

- ✅ Standards-native: real OpenAPI 3.0 `securitySchemes` + correct type vocabulary.
- ✅ Composable functions: `securitySchemes()` is a plain function; no decorators/DI.
- ✅ Bring-your-own crypto: no token lib; `before`/`verify` stays the caller's.
- ✅ Single source of truth: one `Security` carries `scheme` (docs) + `forbidden`/`scopes` (enforcement).
- ✅ Zero new core deps.
- ✅ Testable: scope handlers stay pure functions.

## Breaking change

`Security.handler` → `Security.forbidden`; security-failure response code moves from `400` to `403`. Pre-1.0 (`0.4.1`); called out in the commit footer.

## Verification

`pnpm typecheck` · `pnpm lint` · `pnpm test:no-watch` (66) · `pnpm build` — all green.

## Next (out of scope here)

- **Layer 1** — `bearerAuth` / `apiKey` / `oauth2` scheme builders that pre-fill `scheme` and wire `before`+`unauthorized` via a caller-supplied `verify`.
- **Layer 3** — `Security<User>` typed auth context.

Layer 0 first because building auth on a broken foundation (typo + dangling refs) is wasted effort.