### PR TITLE
feat(security): bearerAuth / apiKey / oauth2 scheme builders (ROADMAP Layer 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,16 +179,19 @@ const apiKeyHandler = getMethod({
 });
 ```
 
-## Secure Routes with Scopes
+## Secure Routes with Scheme Builders
+
+Authentication scheme builders compose extraction, verification, and the
+OpenAPI securityScheme from one config — bring-your-own crypto. A failed
+`verify` returns **401**; a failed scope returns **403**.
 
 ```typescript
 import { Request, Response } from "express";
 import {
-  scope,
-  Security,
+  bearerAuth,
   authPathOp,
+  scope,
   securitySchemes,
-  ScopeHandler,
   putMethod,
   ParamSchema,
 } from "wingnut";
@@ -197,89 +200,106 @@ interface UserAuth extends Request {
   user?: { level: number };
 }
 
-// Build a scope handler to evaluate the user context (session)
-const userLevelAuth =
-  (minLevel: number): ScopeHandler =>
-  (req: UserAuth): boolean =>
-    (req.user?.level ?? 0) >= minLevel;
-
-// A Security definition: enforcement middleware + OpenAPI docs in one place,
-// so the guards and the documentation cannot drift.
-const auth: Security = {
+// A Security: extraction in `before`, verification via `verify`, the correct
+// securityScheme on `scheme`, and a 401 slot — all from one config.
+const auth = bearerAuth({
   // name is the securityScheme key each operation references
   name: "bearerAuth",
-  // OpenAPI securityScheme, emitted into components.securitySchemes
-  scheme: { type: "http", scheme: "bearer", bearerFormat: "JWT" },
-  // optional 401 handler — invoked when authentication fails
-  // (missing/invalid token). Verify the token in a `before` hook.
-  unauthorized: (_req: Request, res: Response) => {
-    res.status(401).send("Unauthenticated");
+  description: "JWT access token",
+  bearerFormat: "JWT",
+  // caller-supplied verification — false or a throw → 401
+  verify: (token, req) => {
+    try {
+      (req as UserAuth).user = verifyJwt(token); // your JWT lib
+      return true;
+    } catch {
+      return false;
+    }
   },
-  // 403 handler — invoked when authenticated but the scope check fails
-  forbidden: (_req: Request, res: Response) => {
-    res.status(403).send("Forbidden");
-  },
+  // authorization half — scope handlers evaluated with OR semantics
   scopes: {
-    // OpenAPI security scopes, evaluated with OR semantics
-    admin: userLevelAuth(100),
-    user: userLevelAuth(10),
+    admin: (req) => ((req as UserAuth).user?.level ?? 0) >= 100,
   },
-  // response schemas surfaced on each secured operation
-  responses: {
-    "401": { description: "Unauthenticated" },
-    "403": { description: "Forbidden" },
-  },
-};
+});
 
-// reusable scope handler to secure admin-only routes
+// authorization layer — authenticated but missing the scope → 403
 const adminAuth = authPathOp(scope(auth, "admin"));
 
-// possible user update schema
 const updateUserSchema: ParamSchema = {
   type: "object",
   properties: {
     user: {
       type: "object",
-      properties: {
-        level: {
-          type: "integer",
-          minimum: 0,
-        },
-      },
+      properties: { level: { type: "integer", minimum: 0 } },
       required: ["level"],
     },
   },
   required: ["user"],
 };
 
-// perform authorization using AdminAuth before updating
+// enforcement middleware is attached automatically; security docs too
 const editUserAPI = adminAuth(
   putMethod({
     description: "Edit a user",
     requestBody: {
       description: "user attributes to edit",
-      content: {
-        "application/json": {
-          schema: updateUserSchema,
-        },
-      },
+      content: { "application/json": { schema: updateUserSchema } },
     },
     middleware: [
-      // express.js RequestHandler — admin-scoped automatically
+      /* express.js RequestHandler */
     ],
   }),
 );
 
 // Emit components.securitySchemes so per-operation security references
-// resolve in Swagger UI / Redoc / Schemathesis. Securities without a
-// scheme are skipped.
+// resolve in Swagger UI / Redoc / Schemathesis.
 const schemes = securitySchemes(auth);
-// → { bearerAuth: { type: "http", scheme: "bearer", bearerFormat: "JWT" } }
+// → { bearerAuth: { type: "http", scheme: "bearer", bearerFormat: "JWT", description: "JWT access token" } }
 ```
 
-Wingnut ships **no** JWT/OAuth/session library — bring your own crypto. Verify
-the token in a `before` hook and populate `req.user`; wingnut only composes
-the middleware and documents the scheme.
+### apiKey & oauth2
+
+```typescript
+import { apiKey, oauth2 } from "wingnut";
+
+// API key in a header (also: in: "query" | "cookie"; cookie needs cookie-parser)
+const key = apiKey({
+  name: "apiKey",
+  in: "header",
+  fieldName: "X-API-Key",
+  verify: (value, req) => {
+    (req as UserAuth).user = lookupKey(value);
+    return !!req.user;
+  },
+});
+
+// OAuth 2.0 — bearer extraction + flow documentation
+const oauth = oauth2({
+  name: "oauth2",
+  flows: {
+    authorizationCode: {
+      authorizationUrl: "https://example.com/oauth/authorize",
+      tokenUrl: "https://example.com/oauth/token",
+      scopes: { read: "read access", write: "write access" },
+    },
+  },
+  verify: (token, req) => {
+    (req as UserAuth).user = verifyAccessToken(token);
+    return !!req.user;
+  },
+});
+```
+
+Wingnut ships **no** JWT/OAuth/session library — bring your own crypto. The
+scheme builders compose the middleware and document the scheme; you supply
+`verify` and populate `req.user`.
+
+### Low-level `Security`
+
+Need a scheme the builders don't cover? Construct a `Security` directly — the
+builders are thin wrappers over the same interface. Set `scheme`, wire
+extraction in `before`, and provide `unauthorized` (401) / `forbidden` (403)
+handlers.
 
 ## Type-Safe Request Values
 
@@ -386,7 +406,7 @@ import swaggerUI from 'swagger-ui-express';
 const ajv = new Ajv();
 ajv.opts.coerceTypes = true;
 
-// `auth` is the Security definition from "Secure Routes with Scopes"
+// `auth` is the Security built by bearerAuth() in "Secure Routes with Scheme Builders"
 const securities: Security[] = [auth];
 
 // base swagger document

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -29,6 +29,10 @@ import {
 } from '../types/open-api-3'
 import { ValidationError } from './errors'
 
+// Layer 1 scheme builders (bearerAuth / apiKey / oauth2). Type-only import of
+// `Security` is erased, so there is no runtime cycle between the two modules.
+export * from './security'
+
 export type AppRoute = { paths: PathItem[]; router: Router }
 
 export type ValidateByParam = Record<

--- a/src/lib/security.ts
+++ b/src/lib/security.ts
@@ -1,0 +1,268 @@
+/**
+ * Layer 1 — Authentication scheme builders.
+ *
+ * Each builder returns a {@link Security} with credential extraction wired into
+ * `before`, the correct OpenAPI {@link SecuritySchemeObject} populated on
+ * `scheme`, and a 401 slot in `unauthorized`. Callers supply a `verify`
+ * function (bring-your-own crypto — wingnut ships no JWT/OAuth/session library)
+ * and the authorization `scopes`; wingnut composes the middleware and emits the
+ * documentation. Failed `verify` → 401; failed scope → 403.
+ *
+ * @see ROADMAP.md "Layer 1 — Authentication scheme builders"
+ */
+import type { Request, RequestHandler } from 'express'
+import type {
+  MediaSchemaItem,
+  NamedHandler,
+  OAuthFlowsObject,
+  SecuritySchemeObject,
+} from '../types/open-api-3'
+import type { Security } from './index'
+
+/**
+ * Caller-supplied credential verification. Returning `false` or throwing routes
+ * the request to the 401 handler. Populate `req.user` here (bring-your-own
+ * crypto).
+ */
+export type Verify = (
+  credential: string,
+  req: Request,
+) => boolean | Promise<boolean>
+
+const BEARER_PATTERN = /^Bearer\s+(.+)$/i
+
+const extractBearerToken = (req: Request): string | undefined => {
+  const match = BEARER_PATTERN.exec(req.headers.authorization ?? '')
+  return match?.[1]
+}
+
+const readQueryParam = (req: Request, name: string): string | undefined => {
+  const value = (req.query as Record<string, unknown>)[name]
+  if (typeof value === 'string') return value
+  if (Array.isArray(value) && typeof value[0] === 'string') return value[0]
+  return undefined
+}
+
+const defaultUnauthorized: RequestHandler = (_req, res) => {
+  res.set('WWW-Authenticate', 'Bearer').status(401).send('Unauthorized')
+}
+
+const defaultForbidden: RequestHandler = (_req, res) => {
+  res.status(403).send('Forbidden')
+}
+
+const defaultResponses: MediaSchemaItem = {
+  '401': { description: 'Unauthenticated' },
+  '403': { description: 'Forbidden' },
+}
+
+/**
+ * Build the `before` extraction/verification handler. Extracts the credential,
+ * runs the caller's `verify`, and either fails closed through the unauthorized
+ * (401) handler or proceeds to `next()` so the scope layer can authorize.
+ */
+const buildVerifyBefore =
+  (
+    extract: (req: Request) => string | undefined,
+    verify: Verify,
+    unauthorized: RequestHandler,
+  ): RequestHandler =>
+  async (req, res, next) => {
+    const credential = extract(req)
+    if (credential === undefined) {
+      unauthorized(req, res, next)
+      return
+    }
+    try {
+      const ok = await verify(credential, req)
+      if (!ok) {
+        unauthorized(req, res, next)
+        return
+      }
+    } catch {
+      unauthorized(req, res, next)
+      return
+    }
+    next()
+  }
+
+/** Fields shared by every scheme-builder config. */
+interface SchemeAuthConfig<S extends string> {
+  /** components.securitySchemes key + per-operation security reference name. */
+  name: string
+  description?: string
+  /** Caller-supplied verification. `false` or a throw → 401. */
+  verify: Verify
+  /** Override the default 401 handler. */
+  unauthorized?: RequestHandler
+  /** Override the default 403 handler. */
+  forbidden?: RequestHandler
+  /** Authorization scope handlers — the authorization half. */
+  scopes?: NamedHandler<S>
+  /** Override or extend the default 401/403 response documentation. */
+  responses?: MediaSchemaItem
+}
+
+const resolveScopes = <S extends string>(
+  scopes: NamedHandler<S> | undefined,
+): NamedHandler<S> => (scopes ?? {}) as NamedHandler<S>
+
+/**
+ * bearerAuth
+ *
+ * Build a `Security` for HTTP Bearer authentication. Extracts the token from
+ * the `Authorization: Bearer <token>` header and emits an
+ * `{ type: 'http', scheme: 'bearer' }` securityScheme.
+ *
+ * ```typescript
+ * interface AuthedRequest extends Request {
+ *   user?: { role: string }
+ * }
+ *
+ * const jwt = bearerAuth({
+ *   name: 'bearerAuth',
+ *   description: 'JWT access token',
+ *   bearerFormat: 'JWT',
+ *   verify: (token, req) => {
+ *     try {
+ *       ;(req as AuthedRequest).user = verifyJwt(token) // caller's lib
+ *       return true
+ *     } catch {
+ *       return false // → 401
+ *     }
+ *   },
+ *   scopes: {
+ *     admin: (req) => (req as AuthedRequest).user?.role === 'admin',
+ *   },
+ * })
+ *
+ * // authorization layer — failed scope → 403
+ * const editUser = authPathOp(scope(jwt, 'admin'))(putMethod({ ... }))
+ * ```
+ */
+export const bearerAuth = <S extends string = string>(
+  config: SchemeAuthConfig<S> & {
+    /** `bearerFormat` for the scheme (e.g. 'JWT'). Omitted from the scheme when unset. */
+    bearerFormat?: string
+  },
+): Security<S> => {
+  const unauthorized = config.unauthorized ?? defaultUnauthorized
+  const scheme: SecuritySchemeObject = { type: 'http', scheme: 'bearer' }
+  if (config.bearerFormat) scheme.bearerFormat = config.bearerFormat
+  if (config.description) scheme.description = config.description
+
+  return {
+    name: config.name,
+    scheme,
+    before: buildVerifyBefore(extractBearerToken, config.verify, unauthorized),
+    unauthorized,
+    forbidden: config.forbidden ?? defaultForbidden,
+    scopes: resolveScopes(config.scopes),
+    responses: { ...defaultResponses, ...config.responses },
+  }
+}
+
+/**
+ * apiKey
+ *
+ * Build a `Security` for API-key authentication in a header, query parameter,
+ * or cookie. Emits an `{ type: 'apiKey', in, name }` securityScheme. Cookie
+ * extraction reads `req.cookies` — supply `cookie-parser` yourself when using
+ * `in: 'cookie'`.
+ *
+ * ```typescript
+ * const key = apiKey({
+ *   name: 'apiKey',
+ *   in: 'header',
+ *   fieldName: 'X-API-Key',
+ *   verify: (value, req) => {
+ *     ;(req as AuthedRequest).user = lookupKey(value)
+ *     return !!req.user
+ *   },
+ * })
+ * ```
+ */
+export const apiKey = <S extends string = string>(
+  config: SchemeAuthConfig<S> & {
+    /** Location of the credential. */
+    in: 'query' | 'header' | 'cookie'
+    /** Header name, query parameter, or cookie name (the OpenAPI `name` field). */
+    fieldName: string
+  },
+): Security<S> => {
+  const unauthorized = config.unauthorized ?? defaultUnauthorized
+  const extract = (req: Request): string | undefined => {
+    if (config.in === 'header') {
+      const value = req.headers[config.fieldName.toLowerCase()]
+      if (typeof value === 'string') return value
+      if (Array.isArray(value) && typeof value[0] === 'string') {
+        return value[0]
+      }
+      return undefined
+    }
+    if (config.in === 'query') return readQueryParam(req, config.fieldName)
+    return req.cookies?.[config.fieldName]
+  }
+  const scheme: SecuritySchemeObject = {
+    type: 'apiKey',
+    in: config.in,
+    name: config.fieldName,
+  }
+  if (config.description) scheme.description = config.description
+
+  return {
+    name: config.name,
+    scheme,
+    before: buildVerifyBefore(extract, config.verify, unauthorized),
+    unauthorized,
+    forbidden: config.forbidden ?? defaultForbidden,
+    scopes: resolveScopes(config.scopes),
+    responses: { ...defaultResponses, ...config.responses },
+  }
+}
+
+/**
+ * oauth2
+ *
+ * Build a `Security` for OAuth 2.0. Access tokens are extracted from the
+ * `Authorization: Bearer <token>` header (same as {@link bearerAuth}); the
+ * `flows` field documents the configured OAuth 2.0 flows on the emitted
+ * `{ type: 'oauth2' }` securityScheme.
+ *
+ * ```typescript
+ * const auth = oauth2({
+ *   name: 'oauth2',
+ *   flows: {
+ *     authorizationCode: {
+ *       authorizationUrl: 'https://example.com/oauth/authorize',
+ *       tokenUrl: 'https://example.com/oauth/token',
+ *       scopes: { read: 'read access', write: 'write access' },
+ *     },
+ *   },
+ *   verify: (token, req) => {
+ *     ;(req as AuthedRequest).user = verifyAccessToken(token)
+ *     return !!req.user
+ *   },
+ * })
+ * ```
+ */
+export const oauth2 = <S extends string = string>(
+  config: SchemeAuthConfig<S> & {
+    /** OpenAPI OAuth Flows Object — required for an oauth2 scheme. */
+    flows: OAuthFlowsObject
+  },
+): Security<S> => {
+  const unauthorized = config.unauthorized ?? defaultUnauthorized
+  const scheme: SecuritySchemeObject = { type: 'oauth2', flows: config.flows }
+  if (config.description) scheme.description = config.description
+
+  return {
+    name: config.name,
+    scheme,
+    before: buildVerifyBefore(extractBearerToken, config.verify, unauthorized),
+    unauthorized,
+    forbidden: config.forbidden ?? defaultForbidden,
+    scopes: resolveScopes(config.scopes),
+    responses: { ...defaultResponses, ...config.responses },
+  }
+}

--- a/src/lib/security.ts
+++ b/src/lib/security.ts
@@ -29,7 +29,10 @@ export type Verify = (
   req: Request,
 ) => boolean | Promise<boolean>
 
-const BEARER_PATTERN = /^Bearer\s+(.+)$/i
+// Token capture starts with \S (non-whitespace) so the \s+ separator and
+// the token cannot overlap — keeps matching linear and avoids the ReDoS
+// (polynomial backtracking) flagged by CodeQL on user-controlled headers.
+const BEARER_PATTERN = /^Bearer\s+(\S.*)$/i
 
 const extractBearerToken = (req: Request): string | undefined => {
   const match = BEARER_PATTERN.exec(req.headers.authorization ?? '')

--- a/src/tests/all.test.ts
+++ b/src/tests/all.test.ts
@@ -11,12 +11,15 @@ import { assert, beforeEach, describe, expect, it, vi } from 'vitest'
 import { app, createSchemaCache, headerParam, path, wingnut } from '../lib'
 import { ValidationError, WingnutError } from '../lib/errors'
 import {
+  apiKey,
   asyncGetMethod,
   asyncPostMethod,
   asyncWrapper,
   authPathOp,
+  bearerAuth,
   getMethod,
   groupByParamIn,
+  oauth2,
   postMethod,
   queryParam,
   Security,
@@ -1152,6 +1155,428 @@ describe('401/403 modeling', () => {
       '403': { description: 'Forbidden' },
     })
     expect(secured.get?.security).toStrictEqual([{ bearerAuth: ['admin'] }])
+  })
+})
+
+describe('bearerAuth', () => {
+  it('emits an http/bearer securityScheme', () => {
+    const auth = bearerAuth({
+      name: 'bearerAuth',
+      description: 'JWT access token',
+      bearerFormat: 'JWT',
+      verify: () => true,
+    })
+    expect(auth.scheme).toStrictEqual({
+      type: 'http',
+      scheme: 'bearer',
+      bearerFormat: 'JWT',
+      description: 'JWT access token',
+    })
+    expect(auth.name).toBe('bearerAuth')
+  })
+
+  it('omits bearerFormat when unset', () => {
+    const auth = bearerAuth({ name: 'bearerAuth', verify: () => true })
+    expect(auth.scheme).toStrictEqual({ type: 'http', scheme: 'bearer' })
+  })
+
+  it('wires extraction into before and fails closed on a missing credential', async () => {
+    const auth = bearerAuth({
+      name: 'bearerAuth',
+      verify: () => true,
+      scopes: { ok: () => true },
+    })
+    const { route, paths, controller } = wingnut(ajv)
+    const app = express()
+    paths(
+      app,
+      controller({
+        prefix: '/api',
+        route: (r: Router) =>
+          route(
+            r,
+            path(
+              '/me',
+              authPathOp(scope(auth, 'ok'))(
+                getMethod({
+                  middleware: [
+                    (_req: Request, res: Response) =>
+                      res.status(200).send('ok'),
+                  ],
+                }),
+              ),
+            ),
+          ),
+      }),
+    )
+    const res = await request(app).get('/api/me')
+    expect(res.status).toBe(401)
+    expect(res.headers['www-authenticate']).toBe('Bearer')
+  })
+
+  it('returns 401 when verify returns false', async () => {
+    const auth = bearerAuth({
+      name: 'bearerAuth',
+      verify: () => false,
+      scopes: { ok: () => true },
+    })
+    const { route, paths, controller } = wingnut(ajv)
+    const app = express()
+    paths(
+      app,
+      controller({
+        prefix: '/api',
+        route: (r: Router) =>
+          route(
+            r,
+            path(
+              '/me',
+              authPathOp(scope(auth, 'ok'))(
+                getMethod({
+                  middleware: [
+                    (_req: Request, res: Response) =>
+                      res.status(200).send('ok'),
+                  ],
+                }),
+              ),
+            ),
+          ),
+      }),
+    )
+    const res = await request(app)
+      .get('/api/me')
+      .set('Authorization', 'Bearer nope')
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 401 when verify throws', async () => {
+    const auth = bearerAuth({
+      name: 'bearerAuth',
+      verify: () => {
+        throw new Error('bad token')
+      },
+      scopes: { ok: () => true },
+    })
+    const { route, paths, controller } = wingnut(ajv)
+    const app = express()
+    paths(
+      app,
+      controller({
+        prefix: '/api',
+        route: (r: Router) =>
+          route(
+            r,
+            path(
+              '/me',
+              authPathOp(scope(auth, 'ok'))(
+                getMethod({
+                  middleware: [
+                    (_req: Request, res: Response) =>
+                      res.status(200).send('ok'),
+                  ],
+                }),
+              ),
+            ),
+          ),
+      }),
+    )
+    const res = await request(app)
+      .get('/api/me')
+      .set('Authorization', 'Bearer boom')
+    expect(res.status).toBe(401)
+  })
+
+  it('passes through when verify succeeds and the scope matches', async () => {
+    interface AuthedRequest extends Request {
+      user?: { role: string }
+    }
+    const auth = bearerAuth({
+      name: 'bearerAuth',
+      verify: (token, req) => {
+        if (token === 'valid') {
+          ;(req as AuthedRequest).user = { role: 'admin' }
+          return true
+        }
+        return false
+      },
+      scopes: {
+        admin: (req: Request) => (req as AuthedRequest).user?.role === 'admin',
+      },
+    })
+    const { route, paths, controller } = wingnut(ajv)
+    const app = express()
+    paths(
+      app,
+      controller({
+        prefix: '/api',
+        route: (r: Router) =>
+          route(
+            r,
+            path(
+              '/me',
+              authPathOp(scope(auth, 'admin'))(
+                getMethod({
+                  middleware: [
+                    (_req: Request, res: Response) =>
+                      res.status(200).send('ok'),
+                  ],
+                }),
+              ),
+            ),
+          ),
+      }),
+    )
+    const res = await request(app)
+      .get('/api/me')
+      .set('Authorization', 'Bearer valid')
+    expect(res.status).toBe(200)
+    expect(res.text).toBe('ok')
+  })
+
+  it('returns 403 when authenticated but the scope fails', async () => {
+    interface AuthedRequest extends Request {
+      user?: { role: string }
+    }
+    const auth = bearerAuth({
+      name: 'bearerAuth',
+      verify: (token, req) => {
+        if (token === 'valid') {
+          ;(req as AuthedRequest).user = { role: 'user' }
+          return true
+        }
+        return false
+      },
+      scopes: {
+        admin: (req: Request) => (req as AuthedRequest).user?.role === 'admin',
+      },
+    })
+    const { route, paths, controller } = wingnut(ajv)
+    const app = express()
+    paths(
+      app,
+      controller({
+        prefix: '/api',
+        route: (r: Router) =>
+          route(
+            r,
+            path(
+              '/me',
+              authPathOp(scope(auth, 'admin'))(
+                getMethod({
+                  middleware: [
+                    (_req: Request, res: Response) =>
+                      res.status(200).send('ok'),
+                  ],
+                }),
+              ),
+            ),
+          ),
+      }),
+    )
+    const res = await request(app)
+      .get('/api/me')
+      .set('Authorization', 'Bearer valid')
+    expect(res.status).toBe(403)
+  })
+
+  it('resolves scheme refs in components.securitySchemes', () => {
+    const auth = bearerAuth({ name: 'bearerAuth', verify: () => true })
+    const schemes = securitySchemes(auth)
+    expect(schemes.bearerAuth).toStrictEqual({
+      type: 'http',
+      scheme: 'bearer',
+    })
+  })
+})
+
+describe('apiKey', () => {
+  it('emits an apiKey securityScheme', () => {
+    const auth = apiKey({
+      name: 'apiKey',
+      in: 'header',
+      fieldName: 'X-API-Key',
+      description: 'server key',
+      verify: () => true,
+    })
+    expect(auth.scheme).toStrictEqual({
+      type: 'apiKey',
+      in: 'header',
+      name: 'X-API-Key',
+      description: 'server key',
+    })
+  })
+
+  it('extracts the key from a header and verifies', async () => {
+    const auth = apiKey({
+      name: 'apiKey',
+      in: 'header',
+      fieldName: 'X-API-Key',
+      verify: (value) => value === 'secret',
+      scopes: { ok: () => true },
+    })
+    const { route, paths, controller } = wingnut(ajv)
+    const app = express()
+    paths(
+      app,
+      controller({
+        prefix: '/api',
+        route: (r: Router) =>
+          route(
+            r,
+            path(
+              '/me',
+              authPathOp(scope(auth, 'ok'))(
+                getMethod({
+                  middleware: [
+                    (_req: Request, res: Response) =>
+                      res.status(200).send('ok'),
+                  ],
+                }),
+              ),
+            ),
+          ),
+      }),
+    )
+    const ok = await request(app).get('/api/me').set('X-API-Key', 'secret')
+    expect(ok.status).toBe(200)
+    const bad = await request(app).get('/api/me').set('X-API-Key', 'wrong')
+    expect(bad.status).toBe(401)
+  })
+
+  it('extracts the key from a query parameter', async () => {
+    const auth = apiKey({
+      name: 'apiKey',
+      in: 'query',
+      fieldName: 'key',
+      verify: (value) => value === 'secret',
+      scopes: { ok: () => true },
+    })
+    const { route, paths, controller } = wingnut(ajv)
+    const app = express()
+    paths(
+      app,
+      controller({
+        prefix: '/api',
+        route: (r: Router) =>
+          route(
+            r,
+            path(
+              '/me',
+              authPathOp(scope(auth, 'ok'))(
+                getMethod({
+                  middleware: [
+                    (_req: Request, res: Response) =>
+                      res.status(200).send('ok'),
+                  ],
+                }),
+              ),
+            ),
+          ),
+      }),
+    )
+    const res = await request(app).get('/api/me?key=secret')
+    expect(res.status).toBe(200)
+  })
+})
+
+describe('oauth2', () => {
+  it('emits an oauth2 securityScheme with flows', () => {
+    const flows = {
+      authorizationCode: {
+        authorizationUrl: 'https://example.com/oauth/authorize',
+        tokenUrl: 'https://example.com/oauth/token',
+        scopes: { read: 'read access', write: 'write access' },
+      },
+    }
+    const auth = oauth2({
+      name: 'oauth2',
+      description: 'OAuth 2.0',
+      flows,
+      verify: () => true,
+    })
+    expect(auth.scheme).toStrictEqual({
+      type: 'oauth2',
+      flows,
+      description: 'OAuth 2.0',
+    })
+  })
+
+  it('extracts a bearer token and fails closed when missing', async () => {
+    const auth = oauth2({
+      name: 'oauth2',
+      flows: {
+        clientCredentials: {
+          tokenUrl: 'https://example.com/oauth/token',
+          scopes: { read: 'read' },
+        },
+      },
+      verify: () => true,
+      scopes: { ok: () => true },
+    })
+    const { route, paths, controller } = wingnut(ajv)
+    const app = express()
+    paths(
+      app,
+      controller({
+        prefix: '/api',
+        route: (r: Router) =>
+          route(
+            r,
+            path(
+              '/me',
+              authPathOp(scope(auth, 'ok'))(
+                getMethod({
+                  middleware: [
+                    (_req: Request, res: Response) =>
+                      res.status(200).send('ok'),
+                  ],
+                }),
+              ),
+            ),
+          ),
+      }),
+    )
+    const res = await request(app).get('/api/me')
+    expect(res.status).toBe(401)
+  })
+})
+
+describe('scheme builders + securitySchemes', () => {
+  it('emits all three scheme types into one components map', () => {
+    const bearer = bearerAuth({
+      name: 'bearerAuth',
+      bearerFormat: 'JWT',
+      verify: () => true,
+    })
+    const key = apiKey({
+      name: 'apiKey',
+      in: 'header',
+      fieldName: 'X-API-Key',
+      verify: () => true,
+    })
+    const oauth = oauth2({
+      name: 'oauth2',
+      flows: {
+        implicit: {
+          authorizationUrl: 'https://example.com/authorize',
+          scopes: { read: 'read' },
+        },
+      },
+      verify: () => true,
+    })
+    expect(securitySchemes(bearer, key, oauth)).toStrictEqual({
+      bearerAuth: { type: 'http', scheme: 'bearer', bearerFormat: 'JWT' },
+      apiKey: { type: 'apiKey', in: 'header', name: 'X-API-Key' },
+      oauth2: {
+        type: 'oauth2',
+        flows: {
+          implicit: {
+            authorizationUrl: 'https://example.com/authorize',
+            scopes: { read: 'read' },
+          },
+        },
+      },
+    })
   })
 })
 

--- a/src/tests/all.test.ts
+++ b/src/tests/all.test.ts
@@ -1158,6 +1158,38 @@ describe('401/403 modeling', () => {
   })
 })
 
+/** Build an Express app secured by `auth` at GET /api/me; shared setup. */
+const buildSecuredApp = (
+  auth: Security,
+  scopeName: string,
+  pre?: RequestHandler,
+) => {
+  const { route, paths, controller } = wingnut(ajv)
+  const app = express()
+  if (pre) app.use(pre)
+  paths(
+    app,
+    controller({
+      prefix: '/api',
+      route: (r: Router) =>
+        route(
+          r,
+          path(
+            '/me',
+            authPathOp(scope(auth, scopeName))(
+              getMethod({
+                middleware: [
+                  (_req: Request, res: Response) => res.status(200).send('ok'),
+                ],
+              }),
+            ),
+          ),
+        ),
+    }),
+  )
+  return app
+}
+
 describe('bearerAuth', () => {
   it('emits an http/bearer securityScheme', () => {
     const auth = bearerAuth({
@@ -1387,6 +1419,32 @@ describe('bearerAuth', () => {
       scheme: 'bearer',
     })
   })
+
+  it('extracts the token after many spaces (ReDoS-resistant separator)', async () => {
+    const auth = bearerAuth({
+      name: 'bearerAuth',
+      verify: (token) => token === 'valid',
+      scopes: { ok: () => true },
+    })
+    // A greedy \s+ separator + many spaces must stay linear and resolve the
+    // token; on the old (\s+)(.+) regex this shape risked polynomial backtracking.
+    const res = await request(buildSecuredApp(auth, 'ok'))
+      .get('/api/me')
+      .set('Authorization', `Bearer ${' '.repeat(50)}valid`)
+    expect(res.status).toBe(200)
+  })
+
+  it('returns 401 when a bearer header is spaces only (no token)', async () => {
+    const auth = bearerAuth({
+      name: 'bearerAuth',
+      verify: () => true,
+      scopes: { ok: () => true },
+    })
+    const res = await request(buildSecuredApp(auth, 'ok'))
+      .get('/api/me')
+      .set('Authorization', `Bearer ${' '.repeat(50)}`)
+    expect(res.status).toBe(401)
+  })
 })
 
 describe('apiKey', () => {
@@ -1476,6 +1534,83 @@ describe('apiKey', () => {
     )
     const res = await request(app).get('/api/me?key=secret')
     expect(res.status).toBe(200)
+  })
+
+  it('extracts the first value when a query param is repeated', async () => {
+    const auth = apiKey({
+      name: 'apiKey',
+      in: 'query',
+      fieldName: 'key',
+      verify: (value) => value === 'secret',
+      scopes: { ok: () => true },
+    })
+    // ?key=secret&key=other → Express parses req.query.key as an array
+    const res = await request(buildSecuredApp(auth, 'ok')).get(
+      '/api/me?key=secret&key=other',
+    )
+    expect(res.status).toBe(200)
+  })
+
+  it('returns 401 when the api-key header is missing', async () => {
+    const auth = apiKey({
+      name: 'apiKey',
+      in: 'header',
+      fieldName: 'X-API-Key',
+      verify: () => true,
+      scopes: { ok: () => true },
+    })
+    const res = await request(buildSecuredApp(auth, 'ok')).get('/api/me')
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 401 when a query api-key is absent', async () => {
+    const auth = apiKey({
+      name: 'apiKey',
+      in: 'query',
+      fieldName: 'key',
+      verify: () => true,
+      scopes: { ok: () => true },
+    })
+    const res = await request(buildSecuredApp(auth, 'ok')).get('/api/me')
+    expect(res.status).toBe(401)
+  })
+
+  it('extracts the first value when a header value is an array', async () => {
+    const auth = apiKey({
+      name: 'apiKey',
+      in: 'header',
+      fieldName: 'X-API-Key',
+      verify: (value) => value === 'secret',
+      scopes: { ok: () => true },
+    })
+    // Custom headers arrive as a string in real HTTP traffic, but the Express
+    // type is string | string[]. Inject an array via pre-middleware to cover
+    // the defensive array branch.
+    const injectArrayHeader: RequestHandler = (req, _res, next) => {
+      ;(req.headers as Record<string, unknown>)['x-api-key'] = [
+        'secret',
+        'extra',
+      ]
+      next()
+    }
+    const res = await request(
+      buildSecuredApp(auth, 'ok', injectArrayHeader),
+    ).get('/api/me')
+    expect(res.status).toBe(200)
+  })
+
+  it('reads the key from a cookie when in: cookie', async () => {
+    const auth = apiKey({
+      name: 'apiKey',
+      in: 'cookie',
+      fieldName: 'session',
+      verify: (value) => value === 'secret',
+      scopes: { ok: () => true },
+    })
+    // Without cookie-parser, req.cookies is undefined → 401. This covers the
+    // cookie extraction branch; the caller wires cookie-parser themselves.
+    const res = await request(buildSecuredApp(auth, 'ok')).get('/api/me')
+    expect(res.status).toBe(401)
   })
 })
 


### PR DESCRIPTION
Implements **Layer 1** of the security-DSL roadmap — the missing authentication half. Builds directly on the Layer 0 foundation merged in #82.

## What & why

Layer 0 fixed the foundation (typo, scheme emission, 401/403 modeling). Layer 1 is the **value-add**: scheme builders that compose extraction + verification + the correct OpenAPI `securityScheme` from one config. This is the reason to adopt wingnut — one definition yields enforcement middleware *and* docs.

```typescript
const jwt = bearerAuth({
  name: 'bearerAuth',
  description: 'JWT access token',
  bearerFormat: 'JWT',
  verify: (token, req) => {           // bring-your-own crypto
    try { req.user = verifyJwt(token); return true }
    catch { return false }            // → 401
  },
  scopes: {                           // authorization half
    admin: (req) => req.user?.role === 'admin',
  },
})

// authorization layer — failed scope → 403
const editUser = authPathOp(scope(jwt, 'admin'))(putMethod({ ... }))
```

## Three builders

| Builder | Extraction | Emitted scheme |
| --- | --- | --- |
| `bearerAuth` | `Authorization: Bearer <token>` | `{ type: 'http', scheme: 'bearer' }` |
| `apiKey` | header / query / cookie (`fieldName`) | `{ type: 'apiKey', in, name }` |
| `oauth2` | bearer token | `{ type: 'oauth2', flows }` |

Each returns a `Security` — composable with the existing `scope()` / `authPathOp()` / `securitySchemes()` primitives. Shared extraction and the async fail-closed `before` handler are factored into one `buildVerifyBefore` helper: a `false` **or thrown** `verify` routes to the 401 handler; success proceeds to `next()` so the scope layer can authorize (→ 403 on failure). 401/403 handlers and response docs are overridable per config.

## Structure

New `src/lib/security.ts`, re-exported from the lib barrel. The `import type { Security } from './index'` is fully erased — no runtime cycle. This separates the security layer into its own module, a small step toward the roadmap's Option C direction (security layer as a separable, framework-neutral unit).

## Integrity constraints (from ROADMAP)

- ✅ Standards-native: each builder emits its correct OpenAPI 3.0 securityScheme type.
- ✅ Composable functions: builders are pure functions returning `Security`; no decorators/DI.
- ✅ Bring-your-own crypto: `verify` is caller-supplied; no JWT/OAuth/session lib added.
- ✅ Single source of truth: one config → extraction middleware + scheme docs.
- ✅ Zero new core deps (express + ajv only).
- ✅ Testable: scope handlers stay pure functions.

## Tests (80 total, +14)

`bearerAuth`: scheme emission (+ `bearerFormat` omitted when unset), missing credential → 401 (with `WWW-Authenticate: Bearer`), false `verify` → 401, throwing `verify` → 401, success + scope match → 200, authenticated but scope fail → 403, scheme ref resolves in `components.securitySchemes`. `apiKey`: scheme emission, header + query extraction with verify. `oauth2`: flows scheme, bearer fail-closed. Combined: all three builders emit into one `components.securitySchemes`.

## Verification

`pnpm typecheck` · `pnpm lint` · `pnpm test:no-watch` (80) · `pnpm build` — all green. Zero new lint warnings (the 5 pre-existing `as any` casts in unrelated tests remain).

## Next (out of scope)

- **Layer 3** — `Security<User>` typed auth context (parallels `WnDataType`).
- **Layer 2** — `allScopes` / `both` composition algebra, only if usage demands.
