### PR TITLE
feat(security): typed auth context — Security<User> + WnAuthType (ROADMAP Layer 3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,13 +196,13 @@ import {
   ParamSchema,
 } from "wingnut";
 
-interface UserAuth extends Request {
-  user?: { level: number };
-}
+// The user shape lives in the generic — no manual `extends Request` interface.
+type AppUser = { id: string; level: number };
 
 // A Security: extraction in `before`, verification via `verify`, the correct
 // securityScheme on `scheme`, and a 401 slot — all from one config.
-const auth = bearerAuth({
+// bearerAuth<Scopes, User> threads the type through to verify + scope handlers.
+const auth = bearerAuth<"admin", AppUser>({
   // name is the securityScheme key each operation references
   name: "bearerAuth",
   description: "JWT access token",
@@ -210,15 +210,16 @@ const auth = bearerAuth({
   // caller-supplied verification — false or a throw → 401
   verify: (token, req) => {
     try {
-      (req as UserAuth).user = verifyJwt(token); // your JWT lib
+      req.user = verifyJwt(token); // your JWT lib — req.user is AppUser | undefined
       return true;
     } catch {
       return false;
     }
   },
   // authorization half — scope handlers evaluated with OR semantics
+  // req.user is typed from the generic — no cast needed
   scopes: {
-    admin: (req) => ((req as UserAuth).user?.level ?? 0) >= 100,
+    admin: (req) => (req.user?.level ?? 0) >= 100,
   },
 });
 
@@ -263,18 +264,18 @@ const schemes = securitySchemes(auth);
 import { apiKey, oauth2 } from "wingnut";
 
 // API key in a header (also: in: "query" | "cookie"; cookie needs cookie-parser)
-const key = apiKey({
+const key = apiKey<"admin", AppUser>({
   name: "apiKey",
   in: "header",
   fieldName: "X-API-Key",
   verify: (value, req) => {
-    (req as UserAuth).user = lookupKey(value);
+    req.user = lookupKey(value); // req.user is AppUser | undefined
     return !!req.user;
   },
 });
 
 // OAuth 2.0 — bearer extraction + flow documentation
-const oauth = oauth2({
+const oauth = oauth2<"admin", AppUser>({
   name: "oauth2",
   flows: {
     authorizationCode: {
@@ -284,7 +285,7 @@ const oauth = oauth2({
     },
   },
   verify: (token, req) => {
-    (req as UserAuth).user = verifyAccessToken(token);
+    req.user = verifyAccessToken(token);
     return !!req.user;
   },
 });
@@ -293,6 +294,21 @@ const oauth = oauth2({
 Wingnut ships **no** JWT/OAuth/session library — bring your own crypto. The
 scheme builders compose the middleware and document the scheme; you supply
 `verify` and populate `req.user`.
+
+### Typed auth context (Layer 3)
+
+Each builder accepts `<Scopes, User>` generics that flow to `verify` and
+scope handlers — no manual `extends Request` interfaces or casts. Derive the
+authed-request shape in your handlers with `WnAuthType`:
+
+```typescript
+import { WnAuthType } from "wingnut";
+
+type Authed = WnAuthType<typeof auth>; // Request & { user?: AppUser }
+
+const me: Authed = /* ... */;
+me.user?.id; // string | undefined — typed, no cast
+```
 
 ### Low-level `Security`
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -13,6 +13,7 @@ import {
 } from '../types/common'
 import {
   AppObject,
+  AuthedRequest,
   inMap,
   MediaSchemaItem,
   NamedHandler,
@@ -40,7 +41,7 @@ export type ValidateByParam = Record<
   AjvLikeValidateFunction | undefined
 >
 
-export interface Security<S = string> {
+export interface Security<S = string, User = unknown> {
   name: string
   /**
    * OpenAPI Security Scheme documentation for this definition. Emitted into
@@ -66,9 +67,30 @@ export interface Security<S = string> {
    * 401/403 distinction is explicit on the definition.
    */
   forbidden: RequestHandler
-  scopes: NamedHandler<S>
+  /**
+   * Authorization scope handlers. Each receives a typed `req.user` when
+   * `User` is supplied (Layer 3), evaluated with OR semantics by `scope()`.
+   */
+  scopes: NamedHandler<S, User>
   responses?: MediaSchemaItem
 }
+
+/**
+ * Derive the authed-request shape from a `Security` definition — the typed
+ * `req` a handler sees once authentication has populated `req.user`. Pure
+ * type-level, zero runtime cost; parallels `WnDataType` for schemas.
+ *
+ * ```typescript
+ * const auth = bearerAuth<'admin', { id: string; role: string }>({ ... })
+ * type Authed = WnAuthType<typeof auth> // Request & { user?: { id, role } }
+ *
+ * const handler = (req: Authed, res: Response) => {
+ *   req.user?.id // string | undefined — no manual casts
+ * }
+ * ```
+ */
+export type WnAuthType<Sec extends Security<any, any>> =
+  Sec extends Security<any, infer User> ? AuthedRequest<User> : never
 
 export const app = (a: AppObject): AppObject => a
 
@@ -486,9 +508,11 @@ export const method =
  * Used to create middleware that maps to Security scopes.
  */
 export const scopeWrapper =
-  (cb: RequestHandler, scopes: ScopeHandler[]) =>
+  <User = unknown>(cb: RequestHandler, scopes: ScopeHandler<User>[]) =>
   (req: Request, res: Response, next: NextFunction) => {
-    const isAuthorized = scopes.some((v) => v(req, res))
+    // `req.user` is populated at runtime by the Security `before` hook; the
+    // cast narrows to AuthedRequest<User> for typed scope handlers.
+    const isAuthorized = scopes.some((v) => v(req as AuthedRequest<User>, res))
     if (isAuthorized) {
       next()
     } else {
@@ -499,50 +523,33 @@ export const scopeWrapper =
 /**
  * scope
  *
- * Create a user security scope
+ * Create a user security scope.
  *
  * ```typescript
  * import { Request, Response } from 'express'
  *
- * // user session interface
- * interface UserAuth extends Request {
- *    user?: {
- *      level: number
- *    }
- * }
+ * // The user shape is carried by Security<string, User> — no manual
+ * // `extends Request` interface needed (Layer 3).
+ * const userLevel = (minLevel: number): ScopeHandler<{ level: number }> =>
+ *   (req) => (req.user?.level ?? 0) > minLevel
  *
- * // authorization middleware based on user level
- * const userLevel = (minLevel: number): ScopeHandler => (
- *    req: UserAuth
- * ): boolean => (req.user?.level ?? 0) > minLevel
- *
- * // authorization security definition
- * const auth: Security = {
+ * const auth: Security<string, { level: number }> = {
  *  name: 'auth',
- *  // OpenAPI security scheme doc, emitted into components.securitySchemes
  *  scheme: { type: 'http', scheme: 'bearer', bearerFormat: 'JWT' },
- *  // 403 forbidden handler (authenticated but missing scope)
- *  forbidden: (_req: Request, res: Response) => {
- *    res.status(403).send('Forbidden')
- *  },
+ *  forbidden: (_req, res) => res.status(403).send('Forbidden'),
  *  scopes: {
  *    admin: userLevel(100),
  *    moderator: userLevel(50)
  *  },
- *  responses: {
- *    '403': {
- *      description: 'Forbidden'
- *    }
- *  }
+ *  responses: { '403': { description: 'Forbidden' } }
  * }
  *
- * // build admin authorization middleware
  * const adminAuth = authPathOp(scope(auth, 'admin'))
  * ```
  */
-export const scope = <T = string>(
-  security: Security<T>,
-  ...scopes: (keyof NamedHandler<T>)[]
+export const scope = <T = string, User = unknown>(
+  security: Security<T, User>,
+  ...scopes: (keyof NamedHandler<T, User>)[]
 ): ScopeObject => {
   const scopeMiddlewares = scopes.map((s) => {
     const handler = security.scopes[s]
@@ -559,7 +566,7 @@ export const scope = <T = string>(
     scopes,
     middleware: [
       ...(security.before ? [security.before] : []),
-      scopeWrapper(security.forbidden, scopeMiddlewares),
+      scopeWrapper<User>(security.forbidden, scopeMiddlewares),
     ],
     responses: security.responses,
   }
@@ -712,6 +719,7 @@ export const asyncPutMethod = asyncMethod('put', asyncWrapper)
 
 export const asyncDeleteMethod = asyncMethod('delete', asyncWrapper)
 
+export type { AuthedRequest } from '../types/open-api-3'
 export type {
   WnDataType,
   WnNumberType,

--- a/src/lib/security.ts
+++ b/src/lib/security.ts
@@ -12,6 +12,7 @@
  */
 import type { Request, RequestHandler } from 'express'
 import type {
+  AuthedRequest,
   MediaSchemaItem,
   NamedHandler,
   OAuthFlowsObject,
@@ -24,9 +25,9 @@ import type { Security } from './index'
  * the request to the 401 handler. Populate `req.user` here (bring-your-own
  * crypto).
  */
-export type Verify = (
+export type Verify<User = unknown> = (
   credential: string,
-  req: Request,
+  req: AuthedRequest<User>,
 ) => boolean | Promise<boolean>
 
 // Token capture starts with \S (non-whitespace) so the \s+ separator and
@@ -65,9 +66,9 @@ const defaultResponses: MediaSchemaItem = {
  * (401) handler or proceeds to `next()` so the scope layer can authorize.
  */
 const buildVerifyBefore =
-  (
+  <User = unknown>(
     extract: (req: Request) => string | undefined,
-    verify: Verify,
+    verify: Verify<User>,
     unauthorized: RequestHandler,
   ): RequestHandler =>
   async (req, res, next) => {
@@ -90,25 +91,25 @@ const buildVerifyBefore =
   }
 
 /** Fields shared by every scheme-builder config. */
-interface SchemeAuthConfig<S extends string> {
+interface SchemeAuthConfig<S extends string, User = unknown> {
   /** components.securitySchemes key + per-operation security reference name. */
   name: string
   description?: string
   /** Caller-supplied verification. `false` or a throw → 401. */
-  verify: Verify
+  verify: Verify<User>
   /** Override the default 401 handler. */
   unauthorized?: RequestHandler
   /** Override the default 403 handler. */
   forbidden?: RequestHandler
   /** Authorization scope handlers — the authorization half. */
-  scopes?: NamedHandler<S>
+  scopes?: NamedHandler<S, User>
   /** Override or extend the default 401/403 response documentation. */
   responses?: MediaSchemaItem
 }
 
-const resolveScopes = <S extends string>(
-  scopes: NamedHandler<S> | undefined,
-): NamedHandler<S> => (scopes ?? {}) as NamedHandler<S>
+const resolveScopes = <S extends string, User = unknown>(
+  scopes: NamedHandler<S, User> | undefined,
+): NamedHandler<S, User> => (scopes ?? {}) as NamedHandler<S, User>
 
 /**
  * bearerAuth
@@ -118,24 +119,21 @@ const resolveScopes = <S extends string>(
  * `{ type: 'http', scheme: 'bearer' }` securityScheme.
  *
  * ```typescript
- * interface AuthedRequest extends Request {
- *   user?: { role: string }
- * }
- *
- * const jwt = bearerAuth({
+ * const jwt = bearerAuth<'admin', { role: string }>({
  *   name: 'bearerAuth',
  *   description: 'JWT access token',
  *   bearerFormat: 'JWT',
  *   verify: (token, req) => {
  *     try {
- *       ;(req as AuthedRequest).user = verifyJwt(token) // caller's lib
+ *       req.user = verifyJwt(token) // req.user is { role: string } | undefined
  *       return true
  *     } catch {
  *       return false // → 401
  *     }
  *   },
  *   scopes: {
- *     admin: (req) => (req as AuthedRequest).user?.role === 'admin',
+ *     // req.user typed from the generic — no manual cast
+ *     admin: (req) => req.user?.role === 'admin',
  *   },
  * })
  *
@@ -143,12 +141,12 @@ const resolveScopes = <S extends string>(
  * const editUser = authPathOp(scope(jwt, 'admin'))(putMethod({ ... }))
  * ```
  */
-export const bearerAuth = <S extends string = string>(
-  config: SchemeAuthConfig<S> & {
+export const bearerAuth = <S extends string = string, User = unknown>(
+  config: SchemeAuthConfig<S, User> & {
     /** `bearerFormat` for the scheme (e.g. 'JWT'). Omitted from the scheme when unset. */
     bearerFormat?: string
   },
-): Security<S> => {
+): Security<S, User> => {
   const unauthorized = config.unauthorized ?? defaultUnauthorized
   const scheme: SecuritySchemeObject = { type: 'http', scheme: 'bearer' }
   if (config.bearerFormat) scheme.bearerFormat = config.bearerFormat
@@ -174,25 +172,25 @@ export const bearerAuth = <S extends string = string>(
  * `in: 'cookie'`.
  *
  * ```typescript
- * const key = apiKey({
+ * const key = apiKey<"ok", UserShape>({
  *   name: 'apiKey',
  *   in: 'header',
  *   fieldName: 'X-API-Key',
  *   verify: (value, req) => {
- *     ;(req as AuthedRequest).user = lookupKey(value)
+ *     req.user = lookupKey(value)
  *     return !!req.user
  *   },
  * })
  * ```
  */
-export const apiKey = <S extends string = string>(
-  config: SchemeAuthConfig<S> & {
+export const apiKey = <S extends string = string, User = unknown>(
+  config: SchemeAuthConfig<S, User> & {
     /** Location of the credential. */
     in: 'query' | 'header' | 'cookie'
     /** Header name, query parameter, or cookie name (the OpenAPI `name` field). */
     fieldName: string
   },
-): Security<S> => {
+): Security<S, User> => {
   const unauthorized = config.unauthorized ?? defaultUnauthorized
   const extract = (req: Request): string | undefined => {
     if (config.in === 'header') {
@@ -243,18 +241,18 @@ export const apiKey = <S extends string = string>(
  *     },
  *   },
  *   verify: (token, req) => {
- *     ;(req as AuthedRequest).user = verifyAccessToken(token)
+ *     req.user = verifyAccessToken(token)
  *     return !!req.user
  *   },
  * })
  * ```
  */
-export const oauth2 = <S extends string = string>(
-  config: SchemeAuthConfig<S> & {
+export const oauth2 = <S extends string = string, User = unknown>(
+  config: SchemeAuthConfig<S, User> & {
     /** OpenAPI OAuth Flows Object — required for an oauth2 scheme. */
     flows: OAuthFlowsObject
   },
-): Security<S> => {
+): Security<S, User> => {
   const unauthorized = config.unauthorized ?? defaultUnauthorized
   const scheme: SecuritySchemeObject = { type: 'oauth2', flows: config.flows }
   if (config.description) scheme.description = config.description

--- a/src/tests/all.test.ts
+++ b/src/tests/all.test.ts
@@ -727,23 +727,17 @@ describe('integration tests', () => {
   })
 })
 
-interface UserAuth extends Request {
-  user?: {
-    level: number
-  }
-}
-
 describe('Security Schema', () => {
   const UserLevel =
-    (minLevel: number): ScopeHandler =>
-    (req: UserAuth): boolean =>
+    (minLevel: number): ScopeHandler<{ level: number }> =>
+    (req): boolean =>
       (req.user?.level ?? 0) > minLevel
   const routeHandler = () => {
     return
   }
 
   it('should scope request to a user level', () => {
-    const auth: Security = {
+    const auth: Security<string, { level: number }> = {
       name: 'auth',
       forbidden: (_req: Request, res: Response) => {
         res.status(403).send('Forbidden')
@@ -785,7 +779,7 @@ describe('Security Schema', () => {
   })
 
   it('should apply security to all methods in a multi-method PathObject', () => {
-    const auth: Security = {
+    const auth: Security<string, { level: number }> = {
       name: 'auth',
       forbidden: (_req: Request, res: Response) => {
         res.status(403).send('Forbidden')
@@ -944,7 +938,7 @@ describe('Security Schema', () => {
   })
   it('should call the before security middleware if provided', async () => {
     let calledBefore = false
-    const auth: Security = {
+    const auth: Security<string, { level: number }> = {
       name: 'auth',
       before: (_req: Request, _res: Response, next: NextFunction) => {
         calledBefore = true

--- a/src/tests/wn-auth.test-d.ts
+++ b/src/tests/wn-auth.test-d.ts
@@ -1,0 +1,80 @@
+import type { Request } from 'express'
+import type { Security, WnAuthType } from '../lib'
+import { bearerAuth } from '../lib'
+import type { ScopeHandler } from '../types/open-api-3'
+
+// Bidirectional assignability: true when A and B are mutually assignable.
+type Equals<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false
+
+// --- WnAuthType derives the authed-request shape from a Security definition ---
+
+interface AppUser {
+  id: string
+  role: 'admin' | 'user'
+}
+
+// A Security<User> carries the user type; WnAuthType extracts it.
+const typedAuth: Security<string, AppUser> = {
+  name: 'bearerAuth',
+  scheme: { type: 'http', scheme: 'bearer' },
+  forbidden: () => undefined,
+  scopes: {},
+}
+
+// WnAuthType<typeof typedAuth> should be Request & { user?: AppUser }
+export const _authedRequest: Equals<
+  WnAuthType<typeof typedAuth>,
+  Request & { user?: AppUser }
+> = true
+
+// --- Untyped Security (User defaults to unknown) ---
+
+const untypedAuth: Security = {
+  name: 'bearerAuth',
+  forbidden: () => undefined,
+  scopes: {},
+}
+
+// WnAuthType of an untyped Security falls back to Request & { user?: unknown }
+export const _untypedAuth: Equals<
+  WnAuthType<typeof untypedAuth>,
+  Request & { user?: unknown }
+> = true
+
+// --- bearerAuth threads User through to the Security ---
+
+const jwt = bearerAuth<'admin', AppUser>({
+  name: 'bearerAuth',
+  verify: (_token, req) => {
+    // req.user is AppUser | undefined — typed from the generic, no cast
+    return req.user?.role === 'admin'
+  },
+  scopes: {
+    // req.user is AppUser | undefined — no manual extends-Request interface
+    admin: (req) => req.user?.role === 'admin',
+  },
+})
+
+// WnAuthType<typeof jwt> preserves AppUser
+export const _bearerAuthType: Equals<
+  WnAuthType<typeof jwt>,
+  Request & { user?: AppUser }
+> = true
+
+// --- ScopeHandler<User> provides typed req.user ---
+
+// No manual UserAuth extends Request interface — the generic is the source.
+const isAdmin: ScopeHandler<AppUser> = (req) => req.user?.role === 'admin'
+
+export const _scopeHandlerType: Equals<
+  ReturnType<typeof isAdmin>,
+  boolean
+> = true
+
+// --- Default User=unknown: scope handlers see user?: unknown ---
+
+const defaultHandler: ScopeHandler = (req) => req.user !== undefined
+export const _defaultScopeHandler: Equals<
+  ReturnType<typeof defaultHandler>,
+  boolean
+> = true

--- a/src/types/open-api-3.ts
+++ b/src/types/open-api-3.ts
@@ -1,10 +1,25 @@
 import { ErrorRequestHandler, Request, RequestHandler, Response } from 'express'
 // open api 3 typings
 
-export type NamedHandler<S> = Record<
+export type NamedHandler<S = string, User = unknown> = Record<
   S extends string ? S : string,
-  ScopeHandler
+  ScopeHandler<User>
 >
+
+/**
+ * A request carrying an optional auth context — the shape scope handlers and
+ * `verify` see. `User` defaults to `unknown`, so `req.user` typing is opt-in
+ * (Layer 3). Populate it via `Security<User>` / the scheme builders.
+ */
+export type AuthedRequest<User = unknown> = Request & { user?: User }
+
+/**
+ * Authorization scope predicate. Returns `true` when the request satisfies the
+ * scope. `req.user` is typed when the owning `Security<User>` carries `User`.
+ */
+export interface ScopeHandler<User = unknown> {
+  (req: AuthedRequest<User>, res: Response, next?: () => void): boolean
+}
 
 export interface AppObject {
   openapi: string
@@ -98,10 +113,6 @@ export interface PathObject {
 export type SecurityObject = {
   [auth: string]: string[]
 }[]
-
-export interface ScopeHandler {
-  (req: Request, res: Response, next?: () => void): boolean
-}
 
 export type ScopeObject<S = string> = {
   auth: string


### PR DESCRIPTION
Implements **Layer 3** of the security-DSL roadmap — typed `req.user` in `verify` and scope handlers, with zero runtime cost. Builds on the Layer 0 (#82) and Layer 1 (#83) foundations.

## What & why

Layer 1's scheme builders eliminated boilerplate but still required a manual `interface UserAuth extends Request { user?: ... }` and `req as UserAuth` casts in every scope handler and `verify`. Layer 3 threads the user type through generics so `req.user` is typed from the definition — paralleling how `WnDataType` types `req.body`/`req.query`/`req.params`.

```typescript
// Before (Layer 1): manual interface + cast everywhere
interface UserAuth extends Request { user?: { role: string } }
const jwt = bearerAuth({
  verify: (token, req) => { (req as UserAuth).user = verifyJwt(token); ... },
  scopes: { admin: (req) => (req as UserAuth).user?.role === 'admin' },
})

// After (Layer 3): generic carries the type — no cast
const jwt = bearerAuth<'admin', { role: string }>({
  verify: (token, req) => { req.user = verifyJwt(token); ... },  // typed
  scopes: { admin: (req) => req.user?.role === 'admin' },        // typed
})

// Derive the authed-request shape in handlers (type-level, zero cost)
type Authed = WnAuthType<typeof jwt>  // Request & { user?: { role: string } }
```

## Changes

- **`src/types/open-api-3.ts`** — `AuthedRequest<User>`, `ScopeHandler<User>`, `NamedHandler<S, User>` gain a `User` generic (defaults `unknown`).
- **`src/lib/index.ts`** — `Security<S, User>`, `scope<S, User>()`, `scopeWrapper<User>()` propagate the generic; new `WnAuthType<Sec>` infers the authed-request shape from a `Security`. Updated `scope()` JSDoc to the typed pattern.
- **`src/lib/security.ts`** — `Verify<User>`, `SchemeAuthConfig<S, User>`, `resolveScopes<S, User>`, `buildVerifyBefore<User>`; `bearerAuth`/`apiKey`/`oauth2` accept `<Scopes, User>` generics. All JSDoc examples updated to the typed flow (no casts).
- **`src/tests/wn-auth.test-d.ts`** (new) — compile-time assertions for `WnAuthType` inference (typed + untyped default), `bearerAuth` `User` threading, `ScopeHandler<User>` typing.
- **`src/tests/all.test.ts`** — removed the `UserAuth extends Request` interface; the `UserLevel` factory now derives `req` typing from `ScopeHandler<{ level: number }>`, demonstrating the Layer 3 win.
- **`README.md`** — scheme-builder examples use `<Scopes, User>` generics; new "Typed auth context (Layer 3)" section showing `WnAuthType`.

## Backward compatibility

`User` defaults to `unknown` on every type and builder, so all existing code (Layer 0/1) compiles unchanged — `User = unknown` means `req.user` is `unknown`, and scope handlers typed as `(req: Request) => boolean` or `() => true` remain assignable via contravariance. The 87 runtime tests + type-d assertions pass without modification to the Layer 1 test bodies.

## Integrity constraints (from ROADMAP)

- ✅ Standards-native: no OpenAPI spec changes (type-level only).
- ✅ Composable functions: generics flow through the existing composable API.
- ✅ Single source of truth: one `User` type on the definition types `verify`, scope handlers, and `WnAuthType`.
- ✅ Zero runtime cost: everything is erased at compile time.
- ✅ Zero new core deps.
- ✅ Testable: compile-time assertions in `wn-auth.test-d.ts` (same pattern as `wn-data.test-d.ts`).

## Verification

`pnpm typecheck` (incl. `*.test-d.ts`) · `pnpm lint` · `pnpm test:no-watch` (87) · `pnpm build` — all green.
