### PR TITLE
docs: drop Layer 3 roadmap markers from code comments

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -69,7 +69,7 @@ export interface Security<S = string, User = unknown> {
   forbidden: RequestHandler
   /**
    * Authorization scope handlers. Each receives a typed `req.user` when
-   * `User` is supplied (Layer 3), evaluated with OR semantics by `scope()`.
+   * `User` is supplied, evaluated with OR semantics by `scope()`.
    */
   scopes: NamedHandler<S, User>
   responses?: MediaSchemaItem
@@ -529,7 +529,7 @@ export const scopeWrapper =
  * import { Request, Response } from 'express'
  *
  * // The user shape is carried by Security<string, User> — no manual
- * // `extends Request` interface needed (Layer 3).
+ * // `extends Request` interface needed.
  * const userLevel = (minLevel: number): ScopeHandler<{ level: number }> =>
  *   (req) => (req.user?.level ?? 0) > minLevel
  *

--- a/src/types/open-api-3.ts
+++ b/src/types/open-api-3.ts
@@ -8,8 +8,8 @@ export type NamedHandler<S = string, User = unknown> = Record<
 
 /**
  * A request carrying an optional auth context — the shape scope handlers and
- * `verify` see. `User` defaults to `unknown`, so `req.user` typing is opt-in
- * (Layer 3). Populate it via `Security<User>` / the scheme builders.
+ * `verify` see. `User` defaults to `unknown`, so `req.user` typing is opt-in.
+ * Populate it via `Security<User>` / the scheme builders.
  */
 export type AuthedRequest<User = unknown> = Request & { user?: User }
 


### PR DESCRIPTION
## What

Removes the `(Layer 3)` scaffolding from three JSDoc comments now that the typed auth context landed in #84.

## Why

These comments were roadmap-progress markers. With Layer 3 shipped and merged to `main`, they're no longer needed in the source — the code stands on its own.

## Changes

| File | Comment |
| --- | --- |
| `src/lib/index.ts:72`  | `User is supplied (Layer 3),` → `User is supplied,` |
| `src/lib/index.ts:532` | `interface needed (Layer 3).` → `interface needed.` |
| `src/types/open-api-3.ts:12` | `opt-in (Layer 3). Populate...` → `opt-in. Populate...` |

Comment-only — no behavioral change. **3 lines** edited, surrounding documentation preserved verbatim.

## Not touched (intentional)

- Layer 0 / Layer 1 references in `src/lib/index.ts` and `src/lib/security.ts` — those layers still describe architectural context.
- `README.md:298` heading `### Typed auth context (Layer 3)` — documentation, not a code comment.

## Verification

- `tsc --noEmit` → clean
- `vitest --run` → 87/87 passing