### PR TITLE
feat(security): composition algebra — allScopes (AND) + both (multi-scheme AND)

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,81 @@ Wingnut ships **no** JWT/OAuth/session library — bring your own crypto. The
 scheme builders compose the middleware and document the scheme; you supply
 `verify` and populate `req.user`.
 
-### Typed auth context (Layer 3)
+### Combining scopes & schemes (AND)
+
+`scope()` OR-matches — a request is authorized when **any** listed scope
+passes. Real authorization rules often need AND: "every one of these
+scopes" or "every one of these schemes". Two combinators cover it, and both
+emit OpenAPI the spec mandates, so docs and enforcement agree.
+
+**`allScopes(auth, ...names)`** — AND within one scheme. Every named scope
+must pass; a request missing any one is forbidden (**403**). The emitted
+`security` entry is identical to `scope()`'s — only the runtime combination
+differs.
+
+```typescript
+import { allScopes, authPathOp } from "wingnut";
+
+const auth = bearerAuth<"read" | "paid", AppUser>({
+  name: "bearerAuth",
+  verify: (token, req) => {
+    req.user = verifyJwt(token);
+    return !!req.user;
+  },
+  scopes: {
+    read: (req) => req.user?.canRead ?? false,
+    paid: (req) => req.user?.isPaid ?? false,
+  },
+});
+
+// Require BOTH 'read' AND 'paid' — a free-tier user with only 'read' is denied.
+// Contrast: scope(auth, "read", "paid") would admit them (OR).
+const paidReader = authPathOp(allScopes(auth, "read", "paid"));
+```
+
+**`both(...requirements)`** — AND across schemes. Each scheme's middleware
+runs in order and every scheme must be satisfied; the first failing scheme
+rejects the request via its own **401** (unauthenticated) or **403**
+(forbidden) handler. `authPathOp` accepts the requirements directly or via
+`both(...)`.
+
+```typescript
+import { apiKey, bearerAuth, both, scope, authPathOp } from "wingnut";
+
+const jwt = bearerAuth<"admin", AppUser>({
+  name: "bearerAuth",
+  verify: (token, req) => {
+    req.user = verifyJwt(token);
+    return !!req.user;
+  },
+  scopes: { admin: (req) => req.user?.level >= 100 },
+});
+
+const key = apiKey<"admin", AppUser>({
+  name: "apiKey",
+  in: "header",
+  fieldName: "X-API-Key",
+  verify: (value, req) => {
+    req.user = lookupKey(value);
+    return !!req.user;
+  },
+  scopes: { admin: (req) => req.user?.level >= 100 },
+});
+
+// Require a valid JWT AND a valid API key. Emits security: [
+//   { bearerAuth: ["admin"] }, { apiKey: ["admin"] }
+// ] — OpenAPI AND's array entries, so Swagger UI / Redoc show both required.
+const twoFactor = authPathOp(both(scope(jwt, "admin"), scope(key, "admin")));
+
+// Equivalent — authPathOp is variadic and accepts the requirements directly.
+const twoFactorAlt = authPathOp(scope(jwt, "admin"), scope(key, "admin"));
+```
+
+There is intentionally **no cross-scheme OR** combinator. OpenAPI 3.0's
+`security` array is AND-only, so an honest `either(...)` cannot be emitted
+without docs/runtime drift. For within-scheme OR, use `scope()`.
+
+### Typed auth context
 
 Each builder accepts `<Scopes, User>` generics that flow to `verify` and
 scope handlers — no manual `extends Request` interfaces or casts. Derive the

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -502,17 +502,23 @@ export const method =
   })
 
 /**
- * scopeWrapper
- *
- * Wraps Express RequestHandler's inside scoped middleware.
- * Used to create middleware that maps to Security scopes.
+ * Build a fail-closed authorization gate from scope predicates. `combine`
+ * decides the strategy: OR (any scope passes — `scope()`) or AND (every
+ * scope passes — `allScopes()`). On success the gate calls `next()`; on
+ * failure it delegates to the Security's `forbidden` (403) handler.
  */
-export const scopeWrapper =
-  <User = unknown>(cb: RequestHandler, scopes: ScopeHandler<User>[]) =>
-  (req: Request, res: Response, next: NextFunction) => {
+const scopeGate =
+  <User = unknown>(
+    cb: RequestHandler,
+    scopes: ScopeHandler<User>[],
+    combine: (results: boolean[]) => boolean,
+  ): RequestHandler =>
+  (req, res, next) => {
     // `req.user` is populated at runtime by the Security `before` hook; the
     // cast narrows to AuthedRequest<User> for typed scope handlers.
-    const isAuthorized = scopes.some((v) => v(req as AuthedRequest<User>, res))
+    const isAuthorized = combine(
+      scopes.map((handler) => handler(req as AuthedRequest<User>, res)),
+    )
     if (isAuthorized) {
       next()
     } else {
@@ -521,9 +527,65 @@ export const scopeWrapper =
   }
 
 /**
+ * scopeWrapper
+ *
+ * OR-semantics gate: authorize when ANY scope predicate passes. Backs
+ * `scope()`. Kept as a named export for callers composing custom middleware.
+ */
+export const scopeWrapper = <User = unknown>(
+  cb: RequestHandler,
+  scopes: ScopeHandler<User>[],
+): RequestHandler =>
+  scopeGate<User>(cb, scopes, (results) => results.some(Boolean))
+
+/**
+ * allScopesWrapper
+ *
+ * AND-semantics gate: authorize only when EVERY scope predicate passes.
+ * Backs `allScopes()`.
+ */
+export const allScopesWrapper = <User = unknown>(
+  cb: RequestHandler,
+  scopes: ScopeHandler<User>[],
+): RequestHandler =>
+  scopeGate<User>(cb, scopes, (results) => results.every(Boolean))
+
+/** Resolve scope names to their handler predicates, throwing on a missing name. */
+const resolveScopeHandlers = <T, User>(
+  security: Security<T, User>,
+  scopes: (keyof NamedHandler<T, User>)[],
+): ScopeHandler<User>[] =>
+  scopes.map((s) => {
+    const handler = security.scopes[s]
+    if (!handler) {
+      throw new Error(
+        `WingnutError: Scope '${String(s)}' not found in security.scopes`,
+      )
+    }
+    return handler
+  })
+
+/** Build a ScopeObject that runs `before` then a gate combining the scopes. */
+const buildScope = <T, User>(
+  security: Security<T, User>,
+  scopes: (keyof NamedHandler<T, User>)[],
+  wrap: (cb: RequestHandler, handlers: ScopeHandler<User>[]) => RequestHandler,
+): ScopeObject => ({
+  auth: security.name,
+  scopes,
+  middleware: [
+    ...(security.before ? [security.before] : []),
+    wrap(security.forbidden, resolveScopeHandlers(security, scopes)),
+  ],
+  responses: security.responses,
+})
+
+/**
  * scope
  *
- * Create a user security scope.
+ * Create a user security scope with OR semantics — the request is
+ * authorized when ANY listed scope predicate passes. Emits a single-scheme
+ * `security` entry.
  *
  * ```typescript
  * import { Request, Response } from 'express'
@@ -550,32 +612,39 @@ export const scopeWrapper =
 export const scope = <T = string, User = unknown>(
   security: Security<T, User>,
   ...scopes: (keyof NamedHandler<T, User>)[]
-): ScopeObject => {
-  const scopeMiddlewares = scopes.map((s) => {
-    const handler = security.scopes[s]
-    if (!handler) {
-      throw new Error(
-        `WingnutError: Scope '${String(s)}' not found in security.scopes`,
-      )
-    }
-    return handler
-  })
+): ScopeObject => buildScope(security, scopes, scopeWrapper<User>)
 
-  return {
-    auth: security.name,
-    scopes,
-    middleware: [
-      ...(security.before ? [security.before] : []),
-      scopeWrapper<User>(security.forbidden, scopeMiddlewares),
-    ],
-    responses: security.responses,
-  }
-}
+/**
+ * allScopes
+ *
+ * AND-require multiple scopes from one Security. Unlike `scope()` — which
+ * authorizes when ANY listed scope passes (OR) — `allScopes()` requires
+ * EVERY listed scope to pass; a request missing any scope is forbidden
+ * (403). The emitted `security` entry is identical to `scope()`'s (a single
+ * scheme carrying all the named scopes); only the runtime combination
+ * differs.
+ *
+ * ```typescript
+ * // Require BOTH 'read' AND 'paid' — a free-tier user with only 'read' is denied.
+ * const paidReader = authPathOp(allScopes(auth, 'read', 'paid'))
+ * ```
+ */
+export const allScopes = <T = string, User = unknown>(
+  security: Security<T, User>,
+  ...scopes: (keyof NamedHandler<T, User>)[]
+): ScopeObject => buildScope(security, scopes, allScopesWrapper<User>)
 
 /**
  * authPathOp
  *
- * Authorization middleware builder.
+ * Authorization middleware builder. Accepts one or more scope requirements:
+ * a single `ScopeObject` (from `scope()` / `allScopes()`) for one scheme, or
+ * several — / the result of `both(...)` — to AND-combine multiple schemes.
+ * Each requirement's middleware runs in order, and every requirement must
+ * pass; the first failing requirement rejects the request via its own 401
+ * (unauthenticated) or 403 (forbidden) handler. The emitted `security`
+ * array mirrors the OpenAPI rule that entries are AND'd, so docs and
+ * enforcement agree.
  *
  * ```typescript
  * // create admin authorization middleware guard
@@ -589,22 +658,48 @@ export const scope = <T = string, User = unknown>(
  *    ]
  *  })
  * )
+ *
+ * // AND-combine two schemes — both bearerAuth AND apiKey are required
+ * authPathOp(both(scope(jwt, 'admin'), scope(key, 'admin')))(
+ *  getMethod({ middleware: [] }),
+ * )
  * ```
  */
 export const authPathOp =
-  (scope: ScopeObject) =>
+  (first: ScopeObject | ScopeObject[], ...rest: ScopeObject[]) =>
   (pathObject: PathObject): PathObject => {
+    const scopes = Array.isArray(first) ? [...first, ...rest] : [first, ...rest]
     const result: PathObject = {}
     for (const [method, operation] of Object.entries(pathObject)) {
       ;(result as Record<string, PathOperation>)[method] = {
         ...operation,
-        security: [{ [scope.auth]: scope.scopes }],
-        scope: [scope],
-        responses: { ...operation.responses, ...scope.responses },
+        security: scopes.map((s) => ({ [s.auth]: s.scopes })),
+        scope: scopes,
+        responses: scopes.reduce<MediaSchemaItem>(
+          (acc, s) => ({ ...acc, ...s.responses }),
+          { ...operation.responses },
+        ),
       }
     }
     return result
   }
+
+/**
+ * both
+ *
+ * AND-combine multiple schemes (e.g. `bearerAuth` AND `apiKey`). Returns
+ * the requirements for `authPathOp`, which runs each scheme's middleware in
+ * order and emits a multi-entry `security` array. OpenAPI AND's array
+ * entries, so the served docs and the runtime enforcement agree: every
+ * scheme must be satisfied. For within-scheme OR/AND use `scope()` /
+ * `allScopes()`.
+ *
+ * ```typescript
+ * // Require a valid JWT AND a valid API key.
+ * authPathOp(both(scope(jwt, 'admin'), scope(key, 'admin')))(putMethod({ ... }))
+ * ```
+ */
+export const both = (...scopes: ScopeObject[]): ScopeObject[] => scopes
 
 /**
  * securitySchemes

--- a/src/tests/all.test.ts
+++ b/src/tests/all.test.ts
@@ -11,12 +11,15 @@ import { assert, beforeEach, describe, expect, it, vi } from 'vitest'
 import { app, createSchemaCache, headerParam, path, wingnut } from '../lib'
 import { ValidationError, WingnutError } from '../lib/errors'
 import {
+  allScopes,
+  allScopesWrapper,
   apiKey,
   asyncGetMethod,
   asyncPostMethod,
   asyncWrapper,
   authPathOp,
   bearerAuth,
+  both,
   getMethod,
   groupByParamIn,
   oauth2,
@@ -35,6 +38,7 @@ import {
   ParamIn,
   ParamType,
   ScopeHandler,
+  ScopeObject,
 } from '../types/open-api-3'
 
 const createParameter = (
@@ -1781,6 +1785,241 @@ describe('ScopeWrapper', () => {
     )
     expect(next).toHaveBeenCalledTimes(1)
     expect(cb).not.toHaveBeenCalled()
+  })
+})
+
+describe('allScopesWrapper', () => {
+  let req: Request
+  let res: Response
+  let next: ReturnType<typeof vi.fn>
+  let cb: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    next = vi.fn()
+    cb = vi.fn()
+    req = {} as Request
+    res = {} as Response
+  })
+
+  it('AND: calls next() only when EVERY scope passes', () => {
+    const scopes = [() => true, () => true]
+    allScopesWrapper(cb as unknown as RequestHandler, scopes)(
+      req,
+      res,
+      next as unknown as NextFunction,
+    )
+    expect(next).toHaveBeenCalledTimes(1)
+    expect(cb).not.toHaveBeenCalled()
+  })
+
+  it('AND: calls cb when any scope fails', () => {
+    const scopes = [() => true, () => false]
+    allScopesWrapper(cb as unknown as RequestHandler, scopes)(
+      req,
+      res,
+      next as unknown as NextFunction,
+    )
+    expect(cb).toHaveBeenCalledTimes(1)
+    expect(next).not.toHaveBeenCalled()
+  })
+
+  it('AND: calls cb when all scopes fail', () => {
+    const scopes = [() => false, () => false]
+    allScopesWrapper(cb as unknown as RequestHandler, scopes)(
+      req,
+      res,
+      next as unknown as NextFunction,
+    )
+    expect(cb).toHaveBeenCalledTimes(1)
+    expect(next).not.toHaveBeenCalled()
+  })
+})
+
+/** A Security whose scopes read boolean flags off request headers — no token
+ * extraction, so the AND/OR combination of scopes is what decides access. */
+const flagAuth = (flags: Record<string, string>): Security => ({
+  name: 'auth',
+  // No credential extraction — scope predicates own the decision.
+  before: (_req, _res, next) => next(),
+  forbidden: (_req, res) => res.status(403).send('Forbidden'),
+  scopes: Object.fromEntries(
+    Object.entries(flags).map(([name, header]) => [
+      name,
+      (req: Request) => req.headers[header] === '1',
+    ]),
+  ) as Record<string, ScopeHandler>,
+  responses: { '403': { description: 'Forbidden' } },
+})
+
+/** A Security that requires a specific header value to authenticate; its
+ * single `ok` scope is satisfied once the header is present. */
+const headerScheme = (name: string, header: string): Security => ({
+  name,
+  before: (req, res, next) => {
+    if (req.headers[header] !== 'ok') {
+      res.status(401).send('Unauthenticated')
+      return
+    }
+    next()
+  },
+  unauthorized: (_req, res) => res.status(401).send('Unauthenticated'),
+  forbidden: (_req, res) => res.status(403).send('Forbidden'),
+  scopes: { ok: (req: Request) => req.headers[header] === 'ok' },
+  responses: {
+    '401': { description: 'Unauthenticated' },
+    '403': { description: 'Forbidden' },
+  },
+})
+
+/** Mount a secured GET /api/me on a fresh Express app and return it. */
+const mountSecured = (requirements: ScopeObject | ScopeObject[]) => {
+  const { route, paths, controller } = wingnut(ajv)
+  const app = express()
+  paths(
+    app,
+    controller({
+      prefix: '/api',
+      route: (r: Router) =>
+        route(
+          r,
+          path(
+            '/me',
+            authPathOp(requirements)(
+              getMethod({
+                middleware: [
+                  (_req: Request, res: Response) => res.status(200).send('ok'),
+                ],
+              }),
+            ),
+          ),
+        ),
+    }),
+  )
+  return app
+}
+
+describe('composition algebra', () => {
+  describe('allScopes (AND within a scheme)', () => {
+    it('throws on a missing scope, like scope()', () => {
+      const auth = flagAuth({ read: 'x-read' })
+      expect(() => allScopes(auth, 'read', 'nonexistent')).toThrow(
+        "WingnutError: Scope 'nonexistent' not found in security.scopes",
+      )
+    })
+
+    it('authorizes only when every named scope passes', async () => {
+      const auth = flagAuth({ read: 'x-read', paid: 'x-paid' })
+      const app = mountSecured(allScopes(auth, 'read', 'paid'))
+
+      // both flags → 200
+      let res = await request(app)
+        .get('/api/me')
+        .set('x-read', '1')
+        .set('x-paid', '1')
+      expect(res.status).toBe(200)
+
+      // only `read` → 403 (missing `paid`)
+      res = await request(app).get('/api/me').set('x-read', '1')
+      expect(res.status).toBe(403)
+
+      // neither → 403
+      res = await request(app).get('/api/me')
+      expect(res.status).toBe(403)
+    })
+
+    it('emits a single-scheme security entry carrying all the scopes', () => {
+      const auth = flagAuth({ read: 'x-read', paid: 'x-paid' })
+      const secured = authPathOp(allScopes(auth, 'read', 'paid'))(
+        getMethod({ middleware: [] }),
+      )
+      // Same single-scheme shape as scope() — only runtime combination differs.
+      expect(secured.get?.security).toStrictEqual([{ auth: ['read', 'paid'] }])
+      expect(secured.get?.scope).toHaveLength(1)
+    })
+
+    it('differs from scope() (OR) — a partial match is denied under AND', async () => {
+      const auth = flagAuth({ read: 'x-read', paid: 'x-paid' })
+      const orApp = mountSecured(scope(auth, 'read', 'paid'))
+      const andApp = mountSecured(allScopes(auth, 'read', 'paid'))
+
+      // Under OR (scope), a `read`-only request is authorized.
+      expect(
+        (await request(orApp).get('/api/me').set('x-read', '1')).status,
+      ).toBe(200)
+      // Under AND (allScopes), the same partial request is forbidden.
+      expect(
+        (await request(andApp).get('/api/me').set('x-read', '1')).status,
+      ).toBe(403)
+    })
+  })
+
+  describe('both (AND across schemes)', () => {
+    it('authorizes only when every scheme is satisfied', async () => {
+      const a = headerScheme('schemeA', 'x-a')
+      const b = headerScheme('schemeB', 'x-b')
+      const app = mountSecured(both(scope(a, 'ok'), scope(b, 'ok')))
+
+      // both schemes → 200
+      let res = await request(app)
+        .get('/api/me')
+        .set('x-a', 'ok')
+        .set('x-b', 'ok')
+      expect(res.status).toBe(200)
+
+      // only schemeA → 401 (schemeB's extraction fails closed)
+      res = await request(app).get('/api/me').set('x-a', 'ok')
+      expect(res.status).toBe(401)
+
+      // neither → 401
+      res = await request(app).get('/api/me')
+      expect(res.status).toBe(401)
+    })
+
+    it('emits a multi-entry security array (OpenAPI AND) and merges responses', () => {
+      const a = headerScheme('schemeA', 'x-a')
+      const b = headerScheme('schemeB', 'x-b')
+      const secured = authPathOp(both(scope(a, 'ok'), scope(b, 'ok')))(
+        getMethod({
+          middleware: [],
+          responses: { '200': { description: 'OK' } },
+        }),
+      )
+      // OpenAPI AND's array entries — both schemes required.
+      expect(secured.get?.security).toStrictEqual([
+        { schemeA: ['ok'] },
+        { schemeB: ['ok'] },
+      ])
+      expect(secured.get?.scope).toHaveLength(2)
+      // 401/403 merged from both schemes, 200 preserved from the operation.
+      expect(secured.get?.responses).toStrictEqual({
+        '200': { description: 'OK' },
+        '401': { description: 'Unauthenticated' },
+        '403': { description: 'Forbidden' },
+      })
+    })
+
+    it('accepts the requirements as rest args too (authPathOp is variadic)', () => {
+      const a = headerScheme('schemeA', 'x-a')
+      const b = headerScheme('schemeB', 'x-b')
+      const viaRest = authPathOp(
+        scope(a, 'ok'),
+        scope(b, 'ok'),
+      )(getMethod({ middleware: [] }))
+      const viaBoth = authPathOp(both(scope(a, 'ok'), scope(b, 'ok')))(
+        getMethod({ middleware: [] }),
+      )
+      expect(viaRest.get?.security).toStrictEqual(viaBoth.get?.security)
+      expect(viaRest.get?.scope).toHaveLength(2)
+    })
+  })
+
+  it('authPathOp stays backward-compatible with a single ScopeObject', () => {
+    const auth = flagAuth({ admin: 'x-admin' })
+    const secured = authPathOp(scope(auth, 'admin'))(
+      getMethod({ middleware: [] }),
+    )
+    expect(secured.get?.security).toStrictEqual([{ auth: ['admin'] }])
+    expect(secured.get?.scope).toHaveLength(1)
   })
 })
 


### PR DESCRIPTION
## What

Layer 2 of the security-DSL roadmap: AND composition on top of the existing OR (). Two new combinators, both OpenAPI-faithful (docs and runtime enforcement agree — no drift).

| Combinator | Semantics | OpenAPI emission |
| --- | --- | --- |
| `allScopes(auth, ...names)` | AND **within** one scheme — every named scope must pass | single-scheme entry, identical to `scope()` |
| `both(...scopeObjects)` | AND **across** schemes — e.g. `bearerAuth` AND `apiKey` | `security: [{A}, {B}]` — OpenAPI AND's array entries |

## Why

The roadmap's Layer 2 closes the authorization-composition gap. `scope()` is OR-only (any scope suffices); real apps also need "all of these scopes" (e.g. `read` AND `paid`) and "all of these schemes" (e.g. JWT AND API key). Both map cleanly to OpenAPI 3.0, so they can be added without compromising the single-source-of-truth integrity constraint.

## Changes

**`src/lib/index.ts`**
- `allScopes(security, ...scopes)` — counterpart to `scope()` using AND (`.every()`).
- `both(...scopes)` — returns the requirements for `authPathOp` to AND-combine.
- `authPathOp` is now **variadic**: `(first: ScopeObject | ScopeObject[], ...rest: ScopeObject[])`. Backward-compatible — `authPathOp(scope(x))` still works; now also accepts `authPathOp(scopeA, scopeB)` or `authPathOp(both(...))`. Emits a multi-entry `security` array and merges responses via reduce.
- `allScopesWrapper` exported (AND gate) alongside the existing `scopeWrapper` (OR gate).
- **Refactor (no behavior change):** `scope()` and `allScopes()` share `resolveScopeHandlers` + `buildScope`; `scopeWrapper`/`allScopesWrapper` share a `scopeGate` combinator. `scope()` output and its missing-scope error are byte-identical.

**`src/tests/all.test.ts`** — +11 tests (`98 passing`, was 87):
- `allScopesWrapper` AND unit tests (all-pass → next; any-fail → cb).
- `allScopes`: runtime enforcement (both → 200, partial → 403, none → 403), missing-scope throw, single-scheme emission, and an explicit OR-vs-AND contrast with `scope()`.
- `both`: runtime AND across schemes (both creds → 200, one missing → 401), multi-entry `security` + merged responses, and variadic-vs-`both` equivalence.
- `authPathOp` backward-compat with a single `ScopeObject`.

## Verification

- `tsc --noEmit` → clean
- `biome check --diagnostic-level=error` → clean
- `vitest --run` → **98/98 passing**

## Not included: `either` (cross-scheme OR)

The roadmap lists `either(...reqs)` under Layer 2 with the caveat "document the spec limitation honestly." **OpenAPI 3.0 has no native cross-scheme OR** — the `security` array is AND-only. A faithful `either` cannot be emitted without either (a) emitting a misleading AND that drifts from runtime OR, or (b) omitting the security requirement so docs under-report. Both violate the project's integrity constraint #4 (single source of truth; no drift). I've left `either` out rather than ship a doc/runtime contradiction; it's worth a separate decision (separate ops vs. a documented approximation) and the whole layer is "build only when real usage demands it."