### PR TITLE
ci: OIDC trusted publishing + supply-chain hardening (attestation / SBOM / scorecard)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -6,12 +6,21 @@ on:
     tags:
       - 'v*'
   pull_request:
+  schedule:
+    - cron: '30 1 * * 1' # weekly Mon 01:30 UTC — drives the scorecard posture scan
+  workflow_dispatch:
+
+# Least privilege at the top level; jobs that need more (id-token, attestations,
+# security-events) grant it explicitly below.
 permissions:
   contents: read
-  id-token: write  # Required for npm provenance
 
 jobs:
+  # ──────────────────────────────────────────────────────────────────────────
+  # build: verify every push / PR. Skipped on schedule (scorecard owns that).
+  # ──────────────────────────────────────────────────────────────────────────
   build:
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -24,7 +33,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 22
-          registry-url: 'https://registry.npmjs.org'
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -50,8 +58,167 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
+  # ──────────────────────────────────────────────────────────────────────────
+  # dependency-review: block PRs that introduce known-vulnerable or
+  # low-Scorecard dependencies. Runs on pull requests only.
+  # ──────────────────────────────────────────────────────────────────────────
+  dependency-review:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Dependency review
+        uses: actions/dependency-review-action@v5
+        with:
+          # Fail on high/critical advisories; warn on moderate/low.
+          fail-on-severity: high
+          # Warn when a changed dependency has a poor OpenSSF Scorecard score.
+          warn-on-openssf-scorecard-level: 5
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # publish: the critical path. OIDC trusted publishing — npm authenticates
+  # with a short-lived token verified against the trusted-publisher config
+  # (ci-cd.yml, cawalch/wingnut, main environment). npm emits provenance
+  # automatically. No NPM_TOKEN secret.
+  # ──────────────────────────────────────────────────────────────────────────
+  publish:
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    # Must match the environment on the npm trusted-publisher config; npm
+    # verifies the OIDC environment claim against this.
+    environment: main
+    permissions:
+      contents: read
+      id-token: write # OIDC: GitHub issues a token npm verifies against the trusted publisher
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          registry-url: 'https://registry.npmjs.org' # required for OIDC auth
+          cache: 'pnpm'
+
+      # Node 22 bundles npm 10; trusted publishing (OIDC) requires npm >= 11.5.1.
+      - name: Upgrade npm
+        run: npm install -g npm@^11
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      # Trusted publishing: npm authenticates via the OIDC token issued to this
+      # job's environment. Provenance is generated automatically under TP.
       - name: Publish to npm
-        if: startsWith(github.ref, 'refs/tags/v')
-        run: pnpm publish --provenance --access public --no-git-checks
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance --access public
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # attest: best-effort supply-chain attestations for the published artifact.
+  # Generates an SBOM (Syft) and binds it + build provenance to the packed
+  # tarball via signed in-toto/Sigstore attestations, queryable with
+  # `gh attestation verify`. Intentionally parallel to publish (does not gate
+  # it): a tooling hiccup here must never block a release.
+  # ──────────────────────────────────────────────────────────────────────────
+  attest:
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # Sigstore signing of the attestations
+      attestations: write # write to GitHub's attestation store
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      # Pack the exact artifact that would be published; attestations bind to it.
+      - name: Pack tarball
+        run: echo "tarball=$(npm pack)" >> "$GITHUB_ENV"
+
+      # Generate a CycloneDX SBOM. Syft scans the installed dependency tree
+      # (handles pnpm's node_modules layout; npm's own `npm sbom` does not).
+      - name: Generate SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          path: .
+          format: cyclonedx-json
+          output-file: sbom.cdx.json
+
+      - name: Attest SBOM to tarball
+        uses: actions/attest-sbom@v4
+        with:
+          subject-path: ${{ env.tarball }}
+          sbom-path: sbom.cdx.json
+
+      - name: Attest build provenance to tarball
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: ${{ env.tarball }}
+
+      # Keep the SBOM + tarball retrievable from the run for audit.
+      - name: Upload SBOM and tarball
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-artifacts
+          path: |
+            sbom.cdx.json
+            ${{ env.tarball }}
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # scorecard: weekly OpenSSF Scorecard posture scan. Surfaces supply-chain
+  # hygiene findings (dangerous workflows, unsigned releases, branch
+  # protection, etc.) in the repo Security tab. Runs on schedule + manual +
+  # main pushes.
+  # ──────────────────────────────────────────────────────────────────────────
+  scorecard:
+    if: >-
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write # post SARIF findings to the Security tab
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Run OpenSSF Scorecard
+        uses: ossf/scorecard-action@v2
+        with:
+          results_format: sarif
+          results_file: results.sarif
+          publish_results: true
+
+      - name: Upload Scorecard results to Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
## What

Two complementary hardenings in one PR, both best practice for npm publishing as of mid-2026:

1. **OIDC trusted publishing** — replaces the long-lived `NPM_TOKEN` secret with short-lived, workflow-scoped OIDC tokens.
2. **Supply-chain hardening** — dependency review on PRs, SBOM + build-provenance attestations on releases, weekly OpenSSF Scorecard posture scans.

## Why

The npm supply-chain threat landscape (account-hijack publishes, compromised transitive deps — e.g. the [March 2026 Axios attack](https://www.armorcode.com/blog/defending-against-npm-supply-chain-attacks-a-practical-guide)) makes these the baseline expectations: tokenless publish, cryptographically-attested provenance + SBOMs, and PR-time dependency vetting. [npm trusted publishing went GA July 2025](https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/); [GitHub Artifact Attestations](https://docs.github.com/actions/security-for-github-actions/using-artifact-attestations) are the companion attestation story. You already configured the trusted publisher on npmjs.com — this PR completes the workflow side.

## Architecture: 5 jobs

| Job | Trigger | Purpose | Critical? |
| --- | --- | --- | --- |
| `build` | push, PR | verify (test/lint/typecheck/coverage) | yes |
| `dependency-review` | pull_request | block PRs introducing high/critical vulns or low-Scorecard deps | gate |
| `publish` | `v*` tag | OIDC publish → npm provenance (automatic) | **critical path** |
| `attest` | `v*` tag | SBOM + build-provenance attestations on the tarball | **best-effort** |
| `scorecard` | weekly + main | OpenSSF posture scan → Security tab | monitor |

**Key safety property:** `publish` depends only on `build`, **not** on `attest`. Attestation is parallel/best-effort — if SBOM/Sigstore/Scorecard tooling hiccups on the first release (it's tag-gated, untestable in PR CI), the package still ships. Publishing infra must not be held hostage to attestation tooling.

## Changes

**Trusted publishing (publish job):**
- `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` → **removed**; npm authenticates via OIDC
- `id-token: write` scoped to the `publish` job only (least privilege)
- `pnpm publish --no-git-checks` → **`npm publish`** (the OIDC client lives in the npm CLI; `pnpm publish` doesn't implement it)
- `npm` upgraded to `^11` (OIDC requires ≥ 11.5.1; Node 22 ships npm 10)
- `registry-url` retained (required for OIDC auth); `--provenance` retained (automatic under TP, flag documents intent)

**Supply-chain hardening:**
- `dependency-review`: `actions/dependency-review-action@v5`, `fail-on-severity: high`, warns on Scorecard < 5
- `attest`: `anchore/sbom-action@v0` (Syft — handles pnpm's `node_modules` layout where `npm sbom` throws `ESBOMPROBLEMS`) → CycloneDX SBOM; `actions/attest-sbom@v4` + `actions/attest-build-provenance@v4` bind it to the `npm pack` tarball via signed in-toto/Sigstore attestations. SBOM + tarball uploaded as run artifacts.
- `scorecard`: `ossf/scorecard-action@v2` → SARIF → `github/codeql-action/upload-sarif@v3` → Security tab
- New triggers: `schedule` (weekly cron) + `workflow_dispatch`

## Verification

- ✅ `actionlint` clean (0 errors) — validates jobs, permissions, action refs, expressions
- ✅ YAML valid; action majors confirmed via `gh api …/releases/latest` (attest `@v4`, sbom-action `@v0`, scorecard `@v2`, dependency-review `@v5`)
- ✅ `npm sbom` tested locally → confirmed Syft is the right call for pnpm
- ✅ `npm pack` tested → deterministic tarball name
- ✅ `repository.url` matches GitHub exactly (required by trusted publishing)

## What this PR's CI does / doesn't exercise

- `build` ✅ and `dependency-review` ✅ run on this PR (first live test of dependency-review)
- `publish`, `attest` are tag-gated → skipped here; first real exercise is `v0.5.0`
- `scorecard` is schedule/manual-gated → skipped here (can trigger via `workflow_dispatch` after merge to test)

## Manual follow-ups (after merge — I can't do these)

1. **Keep `NPM_TOKEN` secret** until the first OIDC publish (v0.5.0) succeeds — npm's [migration tip](https://docs.npmjs.com/trusted-publishers) recommends retaining it as rollback.
2. **After first successful OIDC publish:** delete `NPM_TOKEN`, then on npmjs.com set publishing access to *"Require 2FA and disallow tokens"* for max security.
3. If the `main` GitHub environment has protection rules (required reviewers), `publish` will pause for approval — intended; configure to taste.
4. Tag `v0.5.0` to release the security-DSL work *and* prove the new publish/attest path in one shot.

## References

- [npm trusted publishers](https://docs.npmjs.com/trusted-publishers) · [GA announcement](https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/)
- [GitHub Artifact Attestations](https://docs.github.com/actions/security-for-github-actions/using-artifact-attestations) · [attest-build-provenance](https://github.com/actions/attest-build-provenance) · [attest-sbom](https://github.com/actions/attest-sbom)
- [OpenSSF Scorecard](https://scorecard.dev) · [dependency-review-action](https://github.com/actions/dependency-review-action)
- [OpenSSF: choosing an SBOM tool](https://openssf.org/blog/2025/06/05/choosing-an-sbom-generation-tool)