### PR TITLE
chore(release): v0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wingnut",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "API validation middleware builder based on Open API V3 specs",
   "main": "./dist/index.js",
   "scripts": {


### PR DESCRIPTION
## What

Version bump `0.4.1` → `0.5.0` to cut the release that exercises the new OIDC trusted-publishing pipeline (#88).

## Semver

**Minor.** All changes since `v0.4.1` are additive or backward-compatible fixes:

- **feat(security):** security-DSL Layers 0/1/2/3 — `securitySchemes` emission + 401/403 modeling (#82), `bearerAuth`/`apiKey`/`oauth2` scheme builders (#83), typed `Security<User>` + `WnAuthType` (#84), composition algebra `allScopes` + `both` (#87)
- **feat(types):** `WnDataType` nullable/enum/const/anyOf/oneOf/allOf (#78)
- **fix:** BUG-1..7 (scopeWrapper double-next, paths dup detection, authPathOp all-methods, schema cache id collision, path-merge/schema-ref/param-override) + pre-existing type errors (#79)
- **ci/deps:** TS 6, Biome 2.5, vitest 4.1, pnpm 11, Node 20 target, GHA modernization, OIDC trusted publishing + supply-chain hardening (#65, #66, #77, #88)

No breaking changes. `scope()` output is byte-identical; `authPathOp` stays backward-compatible with its old single-arg form.

## After merge

I'll tag `v0.5.0` on the merge commit and push it — that triggers the `publish` (OIDC → npm) and `attest` (SBOM + provenance) jobs. This is the **first real exercise** of the trusted-publishing path; expect it under the `main` environment (may pause for approval if protected).