### PR TITLE
ci: migrate deprecated attest actions to unified actions/attest@v4

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -172,14 +172,16 @@ jobs:
           format: cyclonedx-json
           output-file: sbom.cdx.json
 
+      # Mode is auto-detected from inputs: subject-path alone → SLSA build
+      # provenance; subject-path + sbom-path → SBOM attestation.
       - name: Attest SBOM to tarball
-        uses: actions/attest-sbom@v4
+        uses: actions/attest@v4
         with:
           subject-path: ${{ env.tarball }}
           sbom-path: sbom.cdx.json
 
       - name: Attest build provenance to tarball
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest@v4
         with:
           subject-path: ${{ env.tarball }}
 


### PR DESCRIPTION
## What

Follow-on to #88 (supply-chain hardening). The `v0.5.0` release run surfaced a deprecation warning from `actions/attest-sbom`:

```
::warning::actions/attest-sbom has been deprecated, please use actions/attest instead
```

This PR migrates **both** attestation steps in the `attest` job to the unified `actions/attest@v4`.

## Why both

- **`actions/attest-sbom@v4`** — emits the runtime deprecation warning (observed in the v0.5.0 run)
- **`actions/attest-build-provenance@v4`** — same situation; its README states *"new implementations should use `actions/attest` instead"* (no runtime warning yet, but identical guidance)

Both have been thin wrappers around `actions/attest` since v4 — the pinned SHA `attest-sbom` delegated to during the v0.5.0 run (`59d89421…`, dated 2026-02-26) is contemporaneous with `actions/attest@v4.1.0`. So this migration swaps a deprecated wrapper for the action it was already calling under the hood.

## Changes

`actions/attest@v4` auto-detects its mode from the inputs supplied, so the migration is purely the action ref — **inputs are unchanged**:

| Step | Before | After |
| --- | --- | --- |
| SBOM attestation | `actions/attest-sbom@v4` + `subject-path` + `sbom-path` | `actions/attest@v4` + `subject-path` + `sbom-path` |
| Build provenance | `actions/attest-build-provenance@v4` + `subject-path` | `actions/attest@v4` + `subject-path` |

Mode detection (per [`actions/attest` README](https://github.com/actions/attest)):
- `subject-path` alone → **SLSA build provenance** (default)
- `subject-path` + `sbom-path` → **SBOM attestation**

Added a comment in the workflow documenting the migration rationale.

## Verification

- ✅ `actionlint` clean (0 errors)
- ✅ Inputs unchanged from the v0.5.0 run that produced verifiable SLSA + CycloneDX attestations
- ✅ `actions/attest@v4` is the same code path the deprecated wrappers delegated to (confirmed via the pinned SHA)

## What this PR's CI does / doesn't exercise

Like `publish`, the `attest` job is tag-gated (`v*`), so it's skipped on this PR — `build` + `dependency-review` run here. The migration is first exercised on the next release tag. High confidence it works: the v0.5.0 attestations verified cleanly via `gh attestation verify`, and this PR calls the same underlying action with identical inputs.

## References

- [`actions/attest`](https://github.com/actions/attest) — unified action (mode table in README)
- [`actions/attest-build-provenance`](https://github.com/actions/attest-build-provenance) — *"new implementations should use `actions/attest` instead"*