### PR TITLE
ci(scorecard): pin ossf/scorecard-action to v2.4.3

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -214,7 +214,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Run OpenSSF Scorecard
-        uses: ossf/scorecard-action@v2
+        uses: ossf/scorecard-action@v2.4.3 # pin; floating @v2 is no longer resolvable by the action runner
         with:
           results_format: sarif
           results_file: results.sarif


### PR DESCRIPTION
## Problem

The weekly scorecard job is failing at job setup:

```
Error: Unable to resolve action `ossf/scorecard-action@v2`, unable to find version `v2`
```

GitHub's action runner no longer resolves the bare floating major tag `@v2`.

## Fix

Pin `ossf/scorecard-action` to `v2.4.3` — current latest of the v2 line (internally bundles scorecard scanner v5.3.0).

```diff
-        uses: ossf/scorecard-action@v2
+        uses: ossf/scorecard-action@v2.4.3
```

## Verification note

This job is gated to `schedule` / `workflow_dispatch` / push to `main`, so it will **not** run on this PR. After merge, trigger it via **workflow_dispatch** on the Actions tab to confirm the resolver error is gone before the weekly cron picks it back up.

## Follow-up (optional)

For maximum supply-chain integrity (and a better Scorecard `Pinned-Dependencies` check), consider pinning to the commit SHA instead of a tag:

```yaml
uses: ossf/scorecard-action@4eaacf0  # v2.4.3
```

Happy to do that in a follow-up if desired.
