### PR TITLE
ci(scorecard): grant id-token: write for publish_results

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -209,6 +209,7 @@ jobs:
     permissions:
       contents: read
       security-events: write # post SARIF findings to the Security tab
+      id-token: write # OIDC token for publish_results (scorecards.dev badge)
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -218,7 +219,7 @@ jobs:
         with:
           results_format: sarif
           results_file: results.sarif
-          publish_results: true
+          publish_results: true # publishes to securityscorecards.dev (powers the badge)
 
       - name: Upload Scorecard results to Security tab
         uses: github/codeql-action/upload-sarif@v3


### PR DESCRIPTION
## Problem

After #91 (pinning the action), the scorecard job now runs but fails at the **publish step** with HTTP 400:

```
error sending scorecard results to webapp: http response 400, status: 400 Bad Request,
error: {"code":400,"message":"error extracting cert info: ensure your GitHub workflow
has \"id-token: write\" permissions"}
```

(retries 4× then fails the run)

## Root cause

`publish_results: true` pushes results to `securityscorecards.dev` (which powers the public Scorecard badge/viewer) using **GitHub OIDC**. That requires the job to have `id-token: write` permission to mint the OIDC token. Our `permissions:` block only had `contents: read` and `security-events: write`.

This is the documented requirement: https://github.com/marketplace/actions/ossf-scorecard-action

## Fix

Add `id-token: write` to the `scorecard` job's permissions:

```diff
     permissions:
       contents: read
       security-events: write # post SARIF findings to the Security tab
+      id-token: write # OIDC token for publish_results (scorecards.dev badge)
```

I kept `publish_results: true` (the alternative — setting it to `false` — would disable the public badge/viewer, which defeats the point for a supply-chain-hardened repo).

## Verification note

Same as #91: the job is gated to `schedule` / `workflow_dispatch` / push to `main`, so it won't run on this PR. After merge, trigger it once via **Actions → scorecard → Run workflow** to confirm the publish step succeeds (look for the "tlog entry created" line with no 400 errors after it).
