### PR TITLE
ci(scorecard): isolate scorecard into its own workflow file

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -6,8 +6,6 @@ on:
     tags:
       - 'v*'
   pull_request:
-  schedule:
-    - cron: '30 1 * * 1' # weekly Mon 01:30 UTC — drives the scorecard posture scan
   workflow_dispatch:
 
 # Least privilege at the top level; jobs that need more (id-token, attestations,
@@ -193,35 +191,3 @@ jobs:
           path: |
             sbom.cdx.json
             ${{ env.tarball }}
-
-  # ──────────────────────────────────────────────────────────────────────────
-  # scorecard: weekly OpenSSF Scorecard posture scan. Surfaces supply-chain
-  # hygiene findings (dangerous workflows, unsigned releases, branch
-  # protection, etc.) in the repo Security tab. Runs on schedule + manual +
-  # main pushes.
-  # ──────────────────────────────────────────────────────────────────────────
-  scorecard:
-    if: >-
-      github.event_name == 'schedule' ||
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'push' && github.ref == 'refs/heads/main')
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      security-events: write # post SARIF findings to the Security tab
-      id-token: write # OIDC token for publish_results (scorecards.dev badge)
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Run OpenSSF Scorecard
-        uses: ossf/scorecard-action@v2.4.3 # pin; floating @v2 is no longer resolvable by the action runner
-        with:
-          results_format: sarif
-          results_file: results.sarif
-          publish_results: true # publishes to securityscorecards.dev (powers the badge)
-
-      - name: Upload Scorecard results to Security tab
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: results.sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,43 @@
+name: OpenSSF Scorecard
+
+# Isolated in its own workflow file on purpose: when publish_results: true,
+# the scorecard-webapp enforces a GLOBAL restriction that no other job in the
+# producing workflow may hold id-token: write (anti-tampering, so a rogue job
+# can't impersonate scorecard to upload forged results). ci-cd.yml's publish
+# and attest jobs legitimately need id-token: write (npm trusted publishing +
+# Sigstore signing), so scorecard must live in a file by itself.
+# Ref: https://github.com/ossf/scorecard-action#workflow-restrictions
+
+on:
+  schedule:
+    - cron: '30 1 * * 1' # weekly Mon 01:30 UTC
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  scorecard:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write # post SARIF findings to the Security tab
+      id-token: write # OIDC token for publish_results (scorecards.dev badge)
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Run OpenSSF Scorecard
+        uses: ossf/scorecard-action@v2.4.3 # pin; floating @v2 is no longer resolvable by the action runner
+        with:
+          results_format: sarif
+          results_file: results.sarif
+          publish_results: true # publishes to securityscorecards.dev (powers the badge)
+
+      - name: Upload Scorecard results to Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
## Problem

After #92 (`id-token: write`), the OIDC cert now mints successfully, but the **publish step** is rejected by the scorecard-webapp with a GLOBAL workflow-restriction failure:

```
workflow verification failed: workflow has a non-scorecard job with id-token permissions,
see https://github.com/ossf/scorecard-action#workflow-restrictions for details.
```

## Root cause

When `publish_results: true`, the scorecard-webapp enforces an **anti-tampering rule on the entire workflow file**: no job other than the one running `ossf/scorecard-action` may hold `id-token: write`. Otherwise a rogue job sharing the workflow could mint an OIDC token and impersonate scorecard to upload forged results.

Our `ci-cd.yml` has **two** other jobs that legitimately need `id-token: write`:
- `publish` — npm OIDC trusted publishing
- `attest` — Sigstore signing of attestations

…so the permissions-only approach from #92 cannot satisfy the restriction. There's no way to keep scorecard in `ci-cd.yml` while keeping `publish_results: true`.

Ref: https://github.com/ossf/scorecard-action#workflow-restrictions

## Fix

Move the `scorecard` job into its own workflow file — **`.github/workflows/scorecard.yml`** — which is the canonical layout OSSF's own starter uses. A file with only one job trivially satisfies the global restriction. The `publish` and `attest` jobs are untouched.

Preserved exactly:
- triggers — `schedule` (same Mon 01:30 UTC cron) + `workflow_dispatch` + push to `main`
- the `v2.4.3` pin (from #91)
- `publish_results: true` (badge / `scorecards.dev` viewer keeps working)
- `id-token: write` + `security-events: write` on the job

Cleanup: dropped the now-dead weekly `schedule` trigger from `ci-cd.yml` (its own comment said it existed only to drive the scorecard job — once that moves out, the cron would run a workflow where every job is gated to skip on schedule).

## Verification

Both workflow files pass `python3 yaml.safe_load`. The scorecard job won't run on this PR (no `pull_request` trigger, by design). After merge, trigger **Actions → OpenSSF Scorecard → Run workflow** and confirm the run goes green with no 400 errors after `tlog entry created`.

## Follow-ups (not in this PR)
- The `build` job comment in `ci-cd.yml` still says *"Skipped on schedule (scorecard owns that)"* — now vacuous since the schedule trigger is gone. Left untouched to keep this diff focused; happy to clean up separately.
