### PR TITLE
ci(scorecard): bump codeql-action upload-sarif to v4.36.2

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -38,6 +38,6 @@ jobs:
           publish_results: true # publishes to securityscorecards.dev (powers the badge)
 
       - name: Upload Scorecard results to Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4.36.2 # v3 deprecated Dec 2026 + runs on Node 20 (forced to Node 24 on 2026-06-16)
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Context

The scorecard run is now fully green (the publish chain from #91/#92/#93 works — no 400s). The remaining log output is a mix of **actionable warnings** and **benign noise**.

## Actionable: two warnings, one fix

Both come from the same line (`github/codeql-action/upload-sarif@v3`):

1. **CodeQL Action v3 deprecation** — "will be deprecated in December 2026"
2. **Node.js 20 runtime deprecation** — "forced to run with Node.js 24 by default starting June 16th, 2026" (today)

v4 runs on a newer Node runtime, so bumping to `v4.36.2` (current latest) clears both at once.

```diff
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4.36.2
```

Pinned to the patch version to match the `scorecard-action@v2.4.3` convention already in this file.

## Not actionable (left as-is): SARIF "not a valid URI" warnings

```
Warning: 'no file associated with this alert' is not a valid URI in
'instance.runs[..].results[..].locations[0].physicalLocation.artifactLocation.uri'
```

These are **expected and benign**. They come from scorecard checks that are inherently *repo-level* rather than source-file findings — e.g. `Branch-Protection`, `Token-Permissions`, `Maintained`, `Dangerous-Workflow`. Since those checks have no file location, the scorecard scanner emits the placeholder string `"no file associated with this alert"`, which GitHub's SARIF validator flags as a non-URI. It's informational; the alerts still upload and appear in the Security tab. Nothing to fix on our end.

## Verification

The scorecard job has no `pull_request` trigger (by design from #93), so it won't run on this PR. After merge, trigger **Actions → OpenSSF Scorecard → Run workflow** — both the CodeQL/Node deprecation warnings should be gone.

## Follow-up (optional)

- Dependabot will likely pick this patch pin up; codeql-action releases frequently (~weekly). If the bump cadence becomes noisy, switching to the floating `@v4` major (which GitHub maintains as a moving tag, unlike the scorecard `@v2` tag that broke in #91) gets auto-updating security patches.
- For max supply-chain integrity (and to satisfy scorecard's `Pinned-Dependencies` check more strictly), both `scorecard-action` and `codeql-action` could be SHA-pinned. Happy to do that in a separate pass.
