### PR TITLE
docs: add OpenSSF Scorecard badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ for validation and documentation.
 
 [![npm version](https://badge.fury.io/js/wingnut.svg)](https://badge.fury.io/js/wingnut)
 [![codecov](https://codecov.io/gh/cawalch/wingnut/graph/badge.svg?token=E7LJCNGZET)](https://codecov.io/gh/cawalch/wingnut)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/cawalch/wingnut/badge)](https://scorecard.dev/viewer/?uri=github.com/cawalch/wingnut)
 
 ## Installation
 


### PR DESCRIPTION
## What

Adds the official OpenSSF Scorecard badge to the README badge cluster:

```markdown
[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/cawalch/wingnut/badge)](https://scorecard.dev/viewer/?uri=github.com/cawalch/wingnut)
```

Clicking it opens the per-check viewer at `scorecard.dev`.

## Why now

The publishing infrastructure is already in place after #91–#94 — `scorecard.yml` runs `ossf/scorecard-action@v2.4.3` with `publish_results: true` and `id-token: write`, so every run pushes results to `securityscorecards.dev`. Verified live just before opening this PR:

- Badge endpoint → HTTP 302 ✅
- Viewer → HTTP 200 ✅
- Aggregate score: **6.2**, `Maintained` check at 10/10
- Last published: 2026-06-16 17:31 UTC (commit `95fb8cd`)

So the data was already flowing — we just weren't surfacing it anywhere. The badge is the missing visibility piece.

## Verification

Badge renders from `api.scorecard.dev/projects/github.com/cawalch/wingnut/badge` (live, 302→image). The score auto-updates on every scorecard run (weekly cron + main pushes + manual dispatch). No workflow changes in this PR — docs only.
