### PR TITLE
docs: add MIT LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 cawalch
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Problem

`package.json` declares `"license": "MIT"`, but the repo had **no LICENSE file** at the root. The OpenSSF Scorecard `License` check scores 0 ("license file not detected") because it inspects files, not `package.json`:

```
0  License  license file not detected
```

Downstream registries/tools that only read files (and not `package.json`) also could not determine the license.

## Fix

Add the standard MIT LICENSE text. Copyright holder matches `package.json` author and git author (`cawalch`).

## Verification

- `License` check will rescore on the next weekly scorecard run (Mon 01:30 UTC), or sooner if triggered via **Actions → OpenSSF Scorecard → Run workflow**.
- No code or workflow changes — docs only.