### PR TITLE
ci: SHA-pin all GitHub Actions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -22,13 +22,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22
           cache: 'pnpm'
@@ -52,7 +52,7 @@ jobs:
         run: pnpm coverage
 
       - name: Publish code coverage report
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -68,10 +68,10 @@ jobs:
       pull-requests: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Dependency review
-        uses: actions/dependency-review-action@v5
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5
         with:
           # Fail on high/critical advisories; warn on moderate/low.
           fail-on-severity: high
@@ -96,13 +96,13 @@ jobs:
       id-token: write # OIDC: GitHub issues a token npm verifies against the trusted publisher
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22
           registry-url: 'https://registry.npmjs.org' # required for OIDC auth
@@ -140,13 +140,13 @@ jobs:
       attestations: write # write to GitHub's attestation store
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22
           cache: 'pnpm'
@@ -164,7 +164,7 @@ jobs:
       # Generate a CycloneDX SBOM. Syft scans the installed dependency tree
       # (handles pnpm's node_modules layout; npm's own `npm sbom` does not).
       - name: Generate SBOM
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
         with:
           path: .
           format: cyclonedx-json
@@ -173,19 +173,19 @@ jobs:
       # Mode is auto-detected from inputs: subject-path alone → SLSA build
       # provenance; subject-path + sbom-path → SBOM attestation.
       - name: Attest SBOM to tarball
-        uses: actions/attest@v4
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4
         with:
           subject-path: ${{ env.tarball }}
           sbom-path: sbom.cdx.json
 
       - name: Attest build provenance to tarball
-        uses: actions/attest@v4
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4
         with:
           subject-path: ${{ env.tarball }}
 
       # Keep the SBOM + tarball retrievable from the run for audit.
       - name: Upload SBOM and tarball
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: release-artifacts
           path: |

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -28,16 +28,16 @@ jobs:
       id-token: write # OIDC token for publish_results (scorecards.dev badge)
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Run OpenSSF Scorecard
-        uses: ossf/scorecard-action@v2.4.3 # pin; floating @v2 is no longer resolvable by the action runner
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_format: sarif
           results_file: results.sarif
           publish_results: true # publishes to securityscorecards.dev (powers the badge)
 
       - name: Upload Scorecard results to Security tab
-        uses: github/codeql-action/upload-sarif@v4.36.2 # v3 deprecated Dec 2026 + runs on Node 20 (forced to Node 24 on 2026-06-16)
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Problem

The OpenSSF Scorecard `Pinned-Dependencies` check scored **0**:

```
0  Pinned-Dependencies  dependency not pinned by hash detected -- score normalized to 0
```

All 19 GitHub Action references across `ci-cd.yml` and `scorecard.yml` were tag-pinned (`@v6`, `@v7`, `@v0`, or patch-level `@v2.4.3`), not hash-pinned. Floating tags are mutable — a compromised upstream release can rewrite `@v6` to point at malicious code that runs in CI.

## Fix

SHA-pin every action to its immutable commit, with a `# vX.Y.Z` comment (which Dependabot reads to auto-bump):

| action | tag | commit |
|---|---|---|
| actions/checkout | v6 | `df4cb1c0…` |
| actions/setup-node | v6 | `48b55a01…` |
| pnpm/action-setup | v6 | `0ebf4713…` |
| codecov/codecov-action | v7 | `fb8b3582…` |
| actions/dependency-review-action | v5 | `a1d282b3…` |
| actions/attest | v4 | `59d89421…` |
| anchore/sbom-action | v0 | `e22c3899…` |
| actions/upload-artifact | v7 | `043fb46d…` |
| ossf/scorecard-action | v2.4.3 | `4eaacf05…` |
| github/codeql-action/upload-sarif | v4.36.2 | `8aad20d1…` |

Notable: `actions/dependency-review-action` has **no `v5` git ref at all** — only `v5.0.0` exists — so `@v5` was a pure runtime-resolved floating tag, illustrating exactly the fragility this eliminates.

## Verification

- Both files pass `python3 yaml.safe_load`.
- `Pinned-Dependencies` check rescores on the next scorecard run (weekly cron Mon 01:30 UTC, or trigger via **Actions → OpenSSF Scorecard → Run workflow**).
- This PR's own `build` job will exercise the pinned `checkout` / `pnpm` / `setup-node` actions, confirming they resolve correctly.

## Note on keeping current

SHA pins don't auto-update. If Dependabot is enabled (config below), it reads the `# vX.Y.Z` comments and opens bump PRs automatically. Worth adding if not already present:

```yaml
# .github/dependabot.yml
version: 2
updates:
  - package-ecosystem: github-actions
    directory: /
    schedule:
      interval: weekly
```

Happy to add that in a follow-up.
