### PR TITLE
Pin npm upgrade to exact version in publish workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -110,7 +110,7 @@ jobs:
 
       # Node 22 bundles npm 10; trusted publishing (OIDC) requires npm >= 11.5.1.
       - name: Upgrade npm
-        run: npm install -g npm@^11
+        run: npm install -g npm@11.19.0
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
Fixes CodeQL alert [PinnedDependenciesID #27](https://github.com/cawalch/wingnut/security/code-scanning/27): the publish job ran \`npm install -g npm@^11\` (version range). Pin to the exact 11.19.0 release — still satisfies the npm >= 11.5.1 requirement for OIDC trusted publishing.