### PR TITLE
Route methods typed as HttpMethod; path-level metadata stays metadata

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -14,6 +14,7 @@ import {
 import {
   AppObject,
   AuthedRequest,
+  HttpMethod,
   inMap,
   MediaSchemaItem,
   NamedHandler,
@@ -93,6 +94,25 @@ export type WnAuthType<Sec extends Security<any, any>> =
   Sec extends Security<any, infer User> ? AuthedRequest<User> : never
 
 export const app = (a: AppObject): AppObject => a
+
+/**
+ * The set of `HttpMethod` keys that route registration actually registers
+ * as Express routes. Other keys on a `PathObject` are OpenAPI path-level
+ * metadata and are deliberately left unrouted.
+ */
+export const HTTP_METHODS: readonly HttpMethod[] = [
+  'get',
+  'post',
+  'put',
+  'patch',
+  'delete',
+  'options',
+  'head',
+  'trace',
+]
+
+export const isHttpMethod = (key: string): key is HttpMethod =>
+  (HTTP_METHODS as readonly string[]).includes(key)
 
 export const groupByParamIn = (
   params: Parameter[],
@@ -269,7 +289,7 @@ export const wingnut = (ajv: AjvLike) => {
       pathOp,
       path,
       method,
-    }: { pathOp: PathOperation; path: string; method: string },
+    }: { pathOp: PathOperation; path: string; method: HttpMethod },
   ) => {
     const wrapper = pathOp.wrapper ?? ((cb) => cb)
 
@@ -338,6 +358,10 @@ export const wingnut = (ajv: AjvLike) => {
     router: pitems.reduce((urtr, pitem) => {
       Object.entries(pitem).forEach(([path, pathObj]) => {
         Object.entries(pathObj).forEach(([method, pathOp]) => {
+          // Path-level metadata (summary, description, ...) is not a route.
+          if (!isHttpMethod(method)) {
+            return
+          }
           mapRouter(urtr, { pathOp, path, method })
         })
       })
@@ -410,7 +434,7 @@ export const wingnut = (ajv: AjvLike) => {
       const p = c(router)
       p.forEach((item) => {
         const path = Object.keys(item)[0]
-        const methods = Object.keys(item[path])
+        const methods = Object.keys(item[path]).filter(isHttpMethod)
         for (const method of methods) {
           const full = `${method} ${path}`
           if (acc.track.has(full)) {
@@ -441,7 +465,7 @@ export const path = (path: string, ...pathObjects: PathObject[]): PathItem => ({
 
 export const asyncMethod =
   (
-    m: string,
+    m: HttpMethod,
     wrapper: (cb: AsyncRequestHandler) => ErrorRequestHandler | RequestHandler,
   ) =>
   (pop: PathOperation): PathObject => ({
@@ -496,7 +520,7 @@ export const asyncWrapper = (
 }
 
 export const method =
-  (m: string) =>
+  (m: HttpMethod) =>
   (pop: PathOperation): PathObject => ({
     [m]: pop,
   })
@@ -671,6 +695,12 @@ export const authPathOp =
     const scopes = Array.isArray(first) ? [...first, ...rest] : [first, ...rest]
     const result: PathObject = {}
     for (const [method, operation] of Object.entries(pathObject)) {
+      // Path-level metadata passes through untouched; only methods get the
+      // `security`/`scope`/`responses` treatment.
+      if (!isHttpMethod(method)) {
+        ;(result as Record<string, unknown>)[method] = operation
+        continue
+      }
       ;(result as Record<string, PathOperation>)[method] = {
         ...operation,
         security: scopes.map((s) => ({ [s.auth]: s.scopes })),
@@ -806,6 +836,9 @@ export const postMethod = method('post')
 export const putMethod = method('put')
 export const patchMethod = method('patch')
 export const deleteMethod = method('delete')
+export const optionsMethod = method('options')
+export const headMethod = method('head')
+export const traceMethod = method('trace')
 export const asyncGetMethod = asyncMethod('get', asyncWrapper)
 
 export const asyncPostMethod = asyncMethod('post', asyncWrapper)
@@ -813,6 +846,9 @@ export const asyncPatchMethod = asyncMethod('patch', asyncWrapper)
 export const asyncPutMethod = asyncMethod('put', asyncWrapper)
 
 export const asyncDeleteMethod = asyncMethod('delete', asyncWrapper)
+export const asyncOptionsMethod = asyncMethod('options', asyncWrapper)
+export const asyncHeadMethod = asyncMethod('head', asyncWrapper)
+export const asyncTraceMethod = asyncMethod('trace', asyncWrapper)
 
 export type { AuthedRequest } from '../types/open-api-3'
 export type {

--- a/src/tests/all.test.ts
+++ b/src/tests/all.test.ts
@@ -15,6 +15,8 @@ import {
   allScopesWrapper,
   apiKey,
   asyncGetMethod,
+  asyncHeadMethod,
+  asyncOptionsMethod,
   asyncPostMethod,
   asyncWrapper,
   authPathOp,
@@ -22,13 +24,18 @@ import {
   both,
   getMethod,
   groupByParamIn,
+  headMethod,
+  isHttpMethod,
   oauth2,
+  optionsMethod,
+  patchMethod,
   postMethod,
   queryParam,
   Security,
   scope,
   scopeWrapper,
   securitySchemes,
+  traceMethod,
   validateBuilder,
   validateParams,
 } from '../lib/index'
@@ -37,6 +44,7 @@ import {
   Parameter,
   ParamIn,
   ParamType,
+  PathObject,
   ScopeHandler,
   ScopeObject,
 } from '../types/open-api-3'
@@ -2801,5 +2809,152 @@ describe('createSchemaCache', () => {
     expect(stats.hits).toBe(0)
     expect(stats.misses).toBe(3)
     expect(stats.hitRate).toBe(0)
+  })
+})
+
+describe('HTTP methods and path-level metadata', () => {
+  it('isHttpMethod recognizes every supported method and rejects metadata keys', () => {
+    for (const m of [
+      'get',
+      'post',
+      'put',
+      'patch',
+      'delete',
+      'options',
+      'head',
+      'trace',
+    ]) {
+      expect(isHttpMethod(m)).toBe(true)
+    }
+    for (const key of ['summary', 'description', 'servers', 'parameters']) {
+      expect(isHttpMethod(key)).toBe(false)
+    }
+  })
+
+  it('registers patch, options, head, and trace routes on Express', async () => {
+    const { route } = wingnut(ajv)
+    const rtr = Router()
+    route(
+      rtr,
+      path(
+        '/widget',
+        patchMethod({
+          middleware: [
+            (_req: Request, res: Response) => res.status(200).send('patched'),
+          ],
+        }),
+        headMethod({
+          middleware: [(_req: Request, res: Response) => res.status(204).end()],
+        }),
+        optionsMethod({
+          middleware: [
+            (_req: Request, res: Response) => res.status(200).send('options'),
+          ],
+        }),
+        traceMethod({
+          middleware: [
+            (_req: Request, res: Response) => res.status(200).send('traced'),
+          ],
+        }),
+      ),
+    )
+    const app = express()
+    app.use(rtr)
+
+    expect((await request(app).patch('/widget')).status).toBe(200)
+    expect((await request(app).head('/widget')).status).toBe(204)
+    expect((await request(app).options('/widget')).status).toBe(200)
+    expect((await request(app).trace('/widget')).status).toBe(200)
+  })
+
+  it('registers async variants for head and options', async () => {
+    const { route } = wingnut(ajv)
+    const rtr = Router()
+    route(
+      rtr,
+      path(
+        '/widget',
+        asyncHeadMethod({
+          middleware: [
+            async (_req: Request, res: Response) => res.status(204).end(),
+          ],
+        }),
+        asyncOptionsMethod({
+          middleware: [
+            async (_req: Request, res: Response) =>
+              res.status(200).send('options'),
+          ],
+        }),
+      ),
+    )
+    const app = express()
+    app.use(rtr)
+
+    expect((await request(app).head('/widget')).status).toBe(204)
+    expect((await request(app).options('/widget')).status).toBe(200)
+  })
+
+  it('does not attempt route registration for path-level metadata', () => {
+    const { route } = wingnut(ajv)
+    const pitem = path(
+      '/widget',
+      {
+        summary: 'Widget endpoint',
+        description: 'Everything about a widget',
+        parameters: [queryParam({ name: 'limit', schema: { type: 'number' } })],
+      },
+      getMethod({
+        middleware: [
+          (_req: Request, res: Response) => res.status(200).send('ok'),
+        ],
+      }),
+    )
+    const rtr = Router()
+    // Pre-fix this blew up: a path-level `parameters` array was treated as
+    // an operation and turned into middleware for a `router.parameters(...)`
+    // call that does not exist.
+    const { router, paths: emitted } = route(rtr, pitem)
+    expect(router.stack.length).toBe(1)
+    expect(
+      (router.stack[0].route as unknown as { methods: Record<string, boolean> })
+        ?.methods.get,
+    ).toBe(true)
+    // metadata survives into the emitted spec untouched
+    expect(emitted[0]['/widget'].summary).toBe('Widget endpoint')
+    expect(emitted[0]['/widget'].description).toBe('Everything about a widget')
+  })
+
+  it('ignores metadata keys when tracking duplicate routes across path items', () => {
+    const { route, paths, controller } = wingnut(ajv)
+    const handler = (_req: Request, res: Response) => res.status(200).send('ok')
+    const ctrl = controller({
+      prefix: '/a',
+      route: (r: Router) =>
+        route(
+          r,
+          path('/x', { summary: 'X' }, getMethod({ middleware: [handler] })),
+          path('/x', { summary: 'X' }, postMethod({ middleware: [handler] })),
+        ),
+    })
+    // Pre-fix the shared `summary` key registered twice under the same path
+    // and tripped the duplicate-route guard.
+    const out = paths(Router(), ctrl)
+    expect(out['/a/x'].get).toBeDefined()
+    expect(out['/a/x'].post).toBeDefined()
+  })
+
+  it('passes path-level metadata through authPathOp untouched', () => {
+    const auth: Security = {
+      name: 'auth',
+      forbidden: (_req, res) => res.status(403).end(),
+      scopes: { admin: () => true },
+    }
+    const po: PathObject = {
+      summary: 'Admin only',
+      get: { middleware: [] },
+    }
+    const out = authPathOp(scope(auth, 'admin'))(po)
+    expect(out.summary).toBe('Admin only')
+    expect(out.get?.security).toEqual([{ auth: ['admin'] }])
   })
 })

--- a/src/types/open-api-3.ts
+++ b/src/types/open-api-3.ts
@@ -103,11 +103,43 @@ export interface PathItem {
   [path: string]: PathObject
 }
 
-export interface PathObject {
+/**
+ * The HTTP methods a route registration can actually pronounce — the keys
+ * of a `PathObject` that become `router[method](...)` calls. Everything
+ * else a `PathObject` may carry is OpenAPI path-level metadata and must
+ * not be treated as a route.
+ */
+export type HttpMethod =
+  | 'get'
+  | 'post'
+  | 'put'
+  | 'patch'
+  | 'delete'
+  | 'options'
+  | 'head'
+  | 'trace'
+
+/**
+ * OpenAPI path-level metadata: the non-method keys of a path item
+ * (`summary`, `description`, `servers`, `parameters`). These describe the
+ * path in the spec; they are not Express routes.
+ */
+export interface PathItemMetadata {
+  summary?: string
+  description?: string
+  servers?: { url: string; description?: string }[]
+  parameters?: Parameter[]
+}
+
+export interface PathObject extends PathItemMetadata {
   get?: PathOperation
   post?: PathOperation
   put?: PathOperation
+  patch?: PathOperation
   delete?: PathOperation
+  options?: PathOperation
+  head?: PathOperation
+  trace?: PathOperation
 }
 
 export type SecurityObject = {


### PR DESCRIPTION
## Why

The router speaks more OpenAPI than it can pronounce. `PathObject` only admitted four methods, route registration iterated every entry like it was a route, and one path-level field away from a user who wanted `summary` in their spec, the machinery was about to start routing nouns — a mystery keycard in a hotel door, hoping to open the right room.

This closes the gap: the spec's vocabulary and Express's now agree, and metadata stays metadata.

## What changed

*   An explicit `HttpMethod` union for methods we can actually pronounce: `get`, `post`, `put`, `patch`, `delete`, `options`, `head`, `trace`.
*   `PathObject` now keeps method keys and OpenAPI path-level metadata (`summary`, `description`, `servers`, `parameters`) in their proper places — metadata documents the spec, it does not become a route.
*   Route registration only calls `router[method](...)` for real methods. `paths()`'s duplicate check and `authPathOp()` learned the same lesson instead of blindly iterating every entry.
*   Method builders for the previously missing methods, plus async variants: `optionsMethod`, `headMethod`, `traceMethod`, `asyncOptionsMethod`, `asyncHeadMethod`, `asyncTraceMethod`.
*   `method()` and `asyncMethod()` now take an `HttpMethod`, so a typo in a custom method is a compile error rather than a silent no-op.

## Acceptance criteria

*   [x] TypeScript accepts `patch`, `options`, `head`, and `trace` operations
*   [x] Path-level metadata does not attempt Express route registration
*   [x] Tests cover at least one metadata field and the newly exposed methods — the new `HTTP methods and path-level metadata` suite registers all four newly exposed methods (sync and async), and feeds a path-level `parameters` array through `route()` — the exact shape that would previously have attempted `router.parameters(...)`
*   [x] Existing route behavior remains unchanged — the prior 98 tests pass untouched

## Verification

`pnpm typecheck`, `pnpm lint`, `pnpm test:no-watch` (104 passing), and `pnpm build` all green.

Closes #141
