### PR TITLE
Normalize header parameter validation without rewriting docs

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -126,6 +126,7 @@ export const groupByParamIn = (
 
 export const validateParams = (
   params: (Partial<Parameter> & { name: string })[],
+  paramIn?: ParamIn,
 ): AjvLikeSchemaObject => {
   const schema: AjvLikeSchemaObject = {
     type: 'object',
@@ -139,12 +140,18 @@ export const validateParams = (
       continue
     }
 
+    // Node lowercases incoming header names, so validate against the
+    // lowercased key for `in: header` params. The authored (mixed-case)
+    // name is preserved on the Parameter itself for emitted docs.
+    const isHeader = paramIn === 'header' || param.in === 'header'
+    const propertyName = isHeader ? param.name.toLowerCase() : param.name
+
     // Copy the param schema so AJV cannot mutate a shared Parameter object
     // across routes during compilation.
-    schema.properties[param.name] = { ...param.schema }
+    schema.properties[propertyName] = { ...param.schema }
 
     if (param.required) {
-      required.add(param.name)
+      required.add(propertyName)
     }
   }
 
@@ -174,7 +181,7 @@ export const validateBuilder =
       }
 
       const paramIn = params[0].in
-      const builtSchema = validateParams(params)
+      const builtSchema = validateParams(params, paramIn)
       schema[paramIn] = builtSchema
       const validator = v.compile(builtSchema)
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -140,9 +140,7 @@ export const validateParams = (
       continue
     }
 
-    // Node lowercases incoming header names, so validate against the
-    // lowercased key for `in: header` params. The authored (mixed-case)
-    // name is preserved on the Parameter itself for emitted docs.
+    // Node lowercases incoming header names.
     const isHeader = paramIn === 'header' || param.in === 'header'
     const propertyName = isHeader ? param.name.toLowerCase() : param.name
 

--- a/src/tests/all.test.ts
+++ b/src/tests/all.test.ts
@@ -166,6 +166,44 @@ describe('validateParams', () => {
     expect(result.properties?.offset).not.toBe(sharedSchema)
     expect(result.properties?.limit).toEqual(sharedSchema)
   })
+
+  it('should lowercase mixed-case header param names', () => {
+    const params: (Partial<Parameter> & { name: string })[] = [
+      {
+        in: 'header',
+        name: 'X-API-Key',
+        required: true,
+        schema: { type: 'string' },
+      },
+      { in: 'header', name: 'Content-Type', schema: { type: 'string' } },
+    ]
+    const result = validateParams(params, 'header')
+    expect(result).toStrictEqual({
+      type: 'object',
+      properties: {
+        'x-api-key': { type: 'string' },
+        'content-type': { type: 'string' },
+      },
+      required: ['x-api-key'],
+    })
+    // The authored names on the Parameter objects must stay untouched so
+    // emitted OpenAPI docs can still present the mixed-case name.
+    expect(params[0].name).toBe('X-API-Key')
+  })
+
+  it('should leave non-header param names untouched', () => {
+    const params: (Partial<Parameter> & { name: string })[] = [
+      {
+        in: 'query',
+        name: 'API_Key',
+        required: true,
+        schema: { type: 'string' },
+      },
+    ]
+    const result = validateParams(params, 'query')
+    expect(result.properties?.API_Key).toBeDefined()
+    expect(result.required).toEqual(['API_Key'])
+  })
 })
 
 describe('param', () => {
@@ -2263,6 +2301,85 @@ describe('headerParam', () => {
     const response = await request(app)
       .get('/api/test')
       .set('x-custom-header', 'abc') // No header set
+    expect(response.status).toBe(400)
+    expect(response.body.err).toBe('WingnutValidationError')
+    expect(response.body.context).toBeDefined() // Check that context is provided
+  })
+
+  it('should validate a mixed-case required header present in the request', async () => {
+    const { route, paths, controller } = wingnut(ajv)
+    const handler = (req: Request, res: Response) => {
+      res.status(200).json(req.headers)
+    }
+    const api = path(
+      '/test',
+      getMethod({
+        parameters: [
+          headerParam({
+            name: 'X-API-Key',
+            schema: { type: 'string', minLength: 1 },
+            required: true,
+          }),
+        ],
+        middleware: [handler],
+      }),
+    )
+    const app = express()
+    paths(
+      app,
+      controller({
+        prefix: '/api',
+        route: (router: Router) => route(router, api),
+      }),
+    )
+    app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+      if (err instanceof ValidationError) {
+        res.status(400).send({ err: err.message, context: err.context })
+      }
+    })
+
+    // Node lowercases incoming headers; authored name stays mixed-case.
+    const response = await request(app)
+      .get('/api/test')
+      .set('x-api-key', 'secret')
+    expect(response.status).toBe(200)
+    // The authored OpenAPI parameter name is preserved for emitted docs.
+    expect(api['/test'].get?.parameters?.[0]?.name).toBe('X-API-Key')
+  })
+
+  it('should fail validation when a mixed-case required header is missing', async () => {
+    const { route, paths, controller } = wingnut(ajv)
+    const handler = (req: Request, res: Response) => {
+      res.status(200).json(req.headers)
+    }
+    const api = path(
+      '/test',
+      getMethod({
+        parameters: [
+          headerParam({
+            name: 'X-API-Key',
+            schema: { type: 'string', minLength: 1 },
+            required: true,
+          }),
+        ],
+        middleware: [handler],
+      }),
+    )
+    const app = express()
+    paths(
+      app,
+      controller({
+        prefix: '/api',
+        route: (router: Router) => route(router, api),
+      }),
+    )
+    app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+      if (err instanceof ValidationError) {
+        res.status(400).send({ err: err.message, context: err.context })
+      }
+    })
+
+    const response = await request(app).get('/api/test') // Header not sent
     expect(response.status).toBe(400)
     expect(response.body.err).toBe('WingnutValidationError')
     expect(response.body.context).toBeDefined() // Check that context is provided

--- a/src/tests/all.test.ts
+++ b/src/tests/all.test.ts
@@ -186,8 +186,6 @@ describe('validateParams', () => {
       },
       required: ['x-api-key'],
     })
-    // The authored names on the Parameter objects must stay untouched so
-    // emitted OpenAPI docs can still present the mixed-case name.
     expect(params[0].name).toBe('X-API-Key')
   })
 
@@ -2338,12 +2336,10 @@ describe('headerParam', () => {
       }
     })
 
-    // Node lowercases incoming headers; authored name stays mixed-case.
     const response = await request(app)
       .get('/api/test')
       .set('x-api-key', 'secret')
     expect(response.status).toBe(200)
-    // The authored OpenAPI parameter name is preserved for emitted docs.
     expect(api['/test'].get?.parameters?.[0]?.name).toBe('X-API-Key')
   })
 


### PR DESCRIPTION
Closes #143

## Changes

- `validateParams` now lowercases `in: header` parameter names when building the AJV schema (property keys + required array), matching how Node/Express present `req.headers`.
- The authored `Parameter.name` is left untouched, so emitted OpenAPI data still presents the mixed-case name (e.g. `X-API-Key`) exactly as written.
- Mirrors the existing lowercasing already done for security-scheme header fields in `security.ts`.

## Tests (4 new, all green)

- Unit: mixed-case required header names are lowercased in the built schema while authored names are preserved.
- Unit: non-header (query) mixed-case names are left untouched.
- E2E: `headerParam({ name: 'X-API-Key', required: true })` validates a request carrying `x-api-key` (success) and fails 400 when the header is missing.

`pnpm test`, `pnpm lint`, `pnpm build`, `pnpm typecheck` all pass.