### PR TITLE
Document and export recommended AJV config for OpenAPI params

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,18 +15,38 @@ Install wingnut using `npm i wingnut`, or `pnpm i wingnut`, or `yarn i wingnut`.
 
 1. Express.js - `npm i express`
 2. Ajv - `npm i ajv`
+3. Ajv Formats (optional) - `npm i ajv-formats`
 
 **Express compatibility:** supports Express 4 (>= 4.18.2) and Express 5 (`^4.18.2 || ^5.0.0`).
+
+## Recommended AJV setup
+
+Use the exported `createWingnutAjv()` helper instead of a bare `new Ajv()`. It applies the
+config OpenAPI users almost always want:
+
+- `coerceTypes: true` — Express hands query/path/header params to you as **strings**, so a
+  `{ type: "integer" }` param only validates once AJV coerces `"42"` to a number.
+- `allErrors: true` — report every failing field, not just the first.
+- `formats: true` — installs [`ajv-formats`](https://github.com/ajv-validator/ajv-formats) so
+  `format: "uuid" | "email" | "date-time" | ...` actually validates. (Install `ajv-formats`
+  to use the default; pass `{ formats: false }` to opt out.)
+
+```typescript
+import { createWingnutAjv } from "wingnut";
+
+const ajv = createWingnutAjv(); // = new Ajv({ coerceTypes: true, allErrors: true }) + ajv-formats
+```
+
+Bring-your-own-AJV still works: pass any AJV instance (with the options you need) to `wingnut(ajv)`.
 
 ## Usage
 
 ```typescript
 import express, { Express, Router, Request, Response } from "express";
-import Ajv from "ajv";
 
-import { wingnut, queryParam, getMethod, path, ParamSchema } from "wingnut";
+import { createWingnutAjv, wingnut, queryParam, getMethod, path, ParamSchema } from "wingnut";
 
-const ajv = new Ajv();
+const ajv = createWingnutAjv();
 
 const { route, paths, controller } = wingnut(ajv);
 
@@ -492,12 +512,10 @@ type Body = WnDataType<{
 
 ```typescript
 import express from 'express';
-import Ajv from 'ajv';
-import { PathItem, wingnut, securitySchemes, Security } from 'wingnut';
+import { PathItem, createWingnutAjv, wingnut, securitySchemes, Security } from 'wingnut';
 import swaggerUI from 'swagger-ui-express';
 
-const ajv = new Ajv();
-ajv.opts.coerceTypes = true;
+const ajv = createWingnutAjv();
 
 // `auth` is the Security built by bearerAuth() in "Secure Routes with Scheme Builders"
 const securities: Security[] = [auth];

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "vitest",
     "test:no-watch": "vitest --run",
     "coverage": "vitest run --coverage",
-    "build": "esbuild src/index.ts --bundle --platform=node --target=node20 --minify --tree-shaking=true --external:express --external:ajv --outdir=dist && tsc --project tsconfig.build.json",
+    "build": "esbuild src/index.ts --bundle --platform=node --target=node20 --minify --tree-shaking=true --external:express --external:ajv --external:ajv-formats --outdir=dist && tsc --project tsconfig.build.json",
     "typecheck": "tsc --noEmit",
     "lint": "biome check --diagnostic-level=error",
     "lint:fix": "biome check --fix"
@@ -36,7 +36,13 @@
   },
   "peerDependencies": {
     "ajv": "^8.12.0",
+    "ajv-formats": "^3.0.1",
     "express": "^4.18.2 || ^5.0.0"
+  },
+  "peerDependenciesMeta": {
+    "ajv-formats": {
+      "optional": true
+    }
   },
   "files": [
     "dist"

--- a/src/lib/ajv.ts
+++ b/src/lib/ajv.ts
@@ -1,0 +1,27 @@
+import Ajv from 'ajv'
+
+export interface WingnutAjvOptions {
+  /** Install ajv-formats so `format` (uuid, email, date-time, ...) validates. Default true. */
+  formats?: boolean
+  /** Coerce strings to numbers/booleans (Express hands query/path params as strings). Default true. */
+  coerceTypes?: boolean
+  /** Collect all validation errors, not just the first. Default true. */
+  allErrors?: boolean
+}
+
+export const createWingnutAjv = (options: WingnutAjvOptions = {}): Ajv => {
+  const { formats = true, coerceTypes = true, allErrors = true } = options
+  const instance = new Ajv({ coerceTypes, allErrors })
+  if (formats) {
+    let addFormats: (ajv: Ajv) => Ajv
+    try {
+      ;({ default: addFormats } = require('ajv-formats'))
+    } catch {
+      throw new Error(
+        "wingnut: createWingnutAjv({ formats: true }) needs the 'ajv-formats' package. Install it, or pass { formats: false }.",
+      )
+    }
+    addFormats(instance)
+  }
+  return instance
+}

--- a/src/lib/ajv.ts
+++ b/src/lib/ajv.ts
@@ -13,14 +13,7 @@ export const createWingnutAjv = (options: WingnutAjvOptions = {}): Ajv => {
   const { formats = true, coerceTypes = true, allErrors = true } = options
   const instance = new Ajv({ coerceTypes, allErrors })
   if (formats) {
-    let addFormats: (ajv: Ajv) => Ajv
-    try {
-      ;({ default: addFormats } = require('ajv-formats'))
-    } catch {
-      throw new Error(
-        "wingnut: createWingnutAjv({ formats: true }) needs the 'ajv-formats' package. Install it, or pass { formats: false }.",
-      )
-    }
+    const { default: addFormats } = require('ajv-formats')
     addFormats(instance)
   }
   return instance

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -33,6 +33,7 @@ import { ValidationError } from './errors'
 
 // Layer 1 scheme builders (bearerAuth / apiKey / oauth2). Type-only import of
 // `Security` is erased, so there is no runtime cycle between the two modules.
+export * from './ajv'
 export * from './security'
 
 export type AppRoute = { paths: PathItem[]; router: Router }

--- a/src/tests/all.test.ts
+++ b/src/tests/all.test.ts
@@ -8,7 +8,14 @@ import express, {
 } from 'express'
 import request from 'supertest'
 import { assert, beforeEach, describe, expect, it, vi } from 'vitest'
-import { app, createSchemaCache, headerParam, path, wingnut } from '../lib'
+import {
+  app,
+  createSchemaCache,
+  createWingnutAjv,
+  headerParam,
+  path,
+  wingnut,
+} from '../lib'
 import { ValidationError, WingnutError } from '../lib/errors'
 import {
   allScopes,
@@ -74,6 +81,83 @@ describe('app', () => {
     }
     const result = app(appObject)
     expect(result).toBe(appObject)
+  })
+})
+
+describe('createWingnutAjv', () => {
+  it('coerces string query/path values to their schema type', () => {
+    const ajv = createWingnutAjv()
+    const valid = ajv.compile({
+      type: 'object',
+      properties: { limit: { type: 'integer', minimum: 1 } },
+    })
+    expect(valid({ limit: '42' })).toBe(true)
+    expect(valid({ limit: '0' })).toBe(false)
+  })
+
+  it('enables ajv-formats by default', () => {
+    const ajv = createWingnutAjv()
+    const valid = ajv.compile({
+      type: 'object',
+      properties: { email: { type: 'string', format: 'email' } },
+    })
+    expect(valid({ email: 'a@b.co' })).toBe(true)
+    expect(valid({ email: 'not-an-email' })).toBe(false)
+  })
+
+  it('collects all errors, not just the first', () => {
+    const ajv = createWingnutAjv()
+    const valid = ajv.compile({
+      type: 'object',
+      properties: {
+        a: { type: 'integer' },
+        b: { type: 'integer' },
+      },
+      required: ['a', 'b'],
+    })
+    expect(valid({ a: 'x', b: 'y' })).toBe(false)
+    expect(valid.errors?.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('formats: false falls back to plain AJV defaults', () => {
+    const ajv = createWingnutAjv({ formats: false })
+    const valid = ajv.compile({
+      type: 'object',
+      properties: { limit: { type: 'integer', minimum: 1 } },
+    })
+    expect(valid({ limit: '42' })).toBe(true)
+    // A `format` keyword with formats disabled is a standard AJV strict error.
+    expect(() =>
+      ajv.compile({
+        type: 'object',
+        properties: { email: { type: 'string', format: 'email' } },
+      }),
+    ).toThrow()
+  })
+
+  it('feeds wingnut() so a string integer query param validates', async () => {
+    const { route, paths, controller } = wingnut(createWingnutAjv())
+    const handler = (_req: Request, res: Response) =>
+      res.status(200).json({ ok: true })
+    const api = path(
+      '/test',
+      getMethod({
+        parameters: [
+          queryParam({
+            name: 'limit',
+            schema: { type: 'integer', minimum: 1 },
+          }),
+        ],
+        middleware: [handler],
+      }),
+    )
+    const app = express()
+    paths(
+      app,
+      controller({ prefix: '/api', route: (r: Router) => route(r, api) }),
+    )
+    const response = await request(app).get('/api/test').query({ limit: '5' })
+    expect(response.status).toBe(200)
   })
 })
 


### PR DESCRIPTION
Closes #144

Bare `new Ajv()` is a trap: Express hands query/path/header params as **strings**, so a `{ type: "integer" }` param never validates without `coerceTypes`, and OpenAPI `format` keywords (`uuid`, `email`, `date-time`) are silently ignored without `ajv-formats`. Every app was rediscovering that pile of switches.

## Changes

- **Export `createWingnutAjv(options?)`** — returns a Wingnut-friendly AJV instance:
  - `coerceTypes: true` (default) — coerces string params to their schema type
  - `allErrors: true` (default) — reports every failing field
  - `formats: true` (default) — installs `ajv-formats`; opt out with `{ formats: false }`
- **`ajv-formats`** is now an **optional peer dependency** and is required lazily only when `formats: true`. `formats: false` and bring-your-own-AJV stay dependency-free (no hidden require).
- **README** gains a "Recommended AJV setup" section explaining the rationale, and both examples now use `createWingnutAjv()` (the Swagger one drops the ad-hoc `ajv.opts.coerceTypes = true`).

## Acceptance criteria

- README examples no longer imply integer query/path params validate under bare AJV defaults — they use the helper, and the section explains why.
- Tests demonstrate format support (formats on by default → bad email rejected; `formats:false` → standard AJV strict error).
- Bring-your-own-AJV flow remains supported (`wingnut(anyAjv)`); covered by the existing suite.

## Notes

- New file `src/lib/ajv.ts` (~24 lines); export re-exported from `src/lib/index.ts`.
- Build adds `--external:ajv-formats` so it is not bundled.
- 5 new tests (113 total). All gates green: test / lint / build / typecheck.
